### PR TITLE
Feature/dashboard economy

### DIFF
--- a/app/components/Dashboard/Economy.js
+++ b/app/components/Dashboard/Economy.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { formatAbp, formatNtz } from '../../utils/amountFormatter';
+
+import WithLoading from '../WithLoading';
+import List from '../List';
+
+const Economy = (props) => {
+  const {
+    totalSupplyPwr,
+    totalSupplyBabz,
+    activeSupplyPwr,
+    activeSupplyBabz,
+    pwrBalance,
+    babzBalance,
+    messages,
+  } = props;
+  // const testRatio = nutzBalance && totalSupplyBabz && nutzBalance.toNumber() / totalSupplyBabz.toNumber();
+  const pwrPercentage = pwrBalance && totalSupplyPwr && pwrBalance.div(totalSupplyPwr).mul(100).toFormat(6);
+  const nutzPercentage = babzBalance && totalSupplyBabz && babzBalance.div(totalSupplyBabz).mul(100).toFormat(6);
+  const ECONOMY_LIST = [
+    [
+      <FormattedMessage {...messages.economyListOwnership} />,
+      <WithLoading
+        isLoading={!babzBalance && !totalSupplyBabz}
+        loadingSize="14px"
+        type="inline"
+      >
+        <FormattedMessage values={{ amount: nutzPercentage }} {...messages.percentUnit} />
+      </WithLoading>,
+      <WithLoading
+        isLoading={!pwrBalance && !totalSupplyPwr}
+        loadingSize="14px"
+        type="inline"
+      >
+        <FormattedMessage values={{ amount: pwrPercentage }} {...messages.percentUnit} />
+      </WithLoading>,
+    ],
+    [
+      <FormattedMessage {...messages.economyListActive} />,
+      <WithLoading
+        isLoading={!totalSupplyBabz}
+        loadingSize="14px"
+        type="inline"
+      >
+        <FormattedMessage
+          values={{ amount: formatNtz(activeSupplyBabz) }}
+          {...messages.ntzUnit}
+        />
+      </WithLoading>,
+      <WithLoading
+        isLoading={!activeSupplyPwr}
+        loadingSize="14px"
+        type="inline"
+      >
+        <FormattedMessage values={{ amount: formatAbp(activeSupplyPwr) }} {...messages.abpUnit} />
+      </WithLoading>,
+    ],
+    [
+      <FormattedMessage {...messages.economyListTotal} />,
+      <WithLoading
+        isLoading={!totalSupplyBabz}
+        loadingSize="14px"
+        type="inline"
+      >
+        <FormattedMessage values={{ amount: formatNtz(totalSupplyBabz) }} {...messages.ntzUnit} />
+      </WithLoading>,
+      <WithLoading
+        isLoading={!totalSupplyPwr}
+        loadingSize="14px"
+        type="inline"
+      >
+        <FormattedMessage values={{ amount: formatAbp(totalSupplyPwr) }} {...messages.abpUnit} />
+      </WithLoading>,
+    ],
+  ];
+  const COL_STYLE = {
+    0: { width: 120 },
+    1: { textAlign: 'left', width: 10, whiteSpace: 'nowrap' },
+    2: { textAlign: 'left', width: 10, whiteSpace: 'nowrap' },
+  };
+  return (
+    <div>
+      <List
+        items={ECONOMY_LIST}
+        headers={['', 'Nutz', 'Power']}
+        columnsStyle={COL_STYLE}
+      />
+    </div>
+  );
+};
+Economy.propTypes = {
+  totalSupplyPwr: PropTypes.object,
+  totalSupplyBabz: PropTypes.object,
+  activeSupplyPwr: PropTypes.object,
+  activeSupplyBabz: PropTypes.object,
+  pwrBalance: PropTypes.object,
+  babzBalance: PropTypes.object,
+  messages: PropTypes.object,
+};
+
+export default Economy;

--- a/app/components/Dashboard/Economy.js
+++ b/app/components/Dashboard/Economy.js
@@ -17,7 +17,6 @@ const Economy = (props) => {
     babzBalance,
     messages,
   } = props;
-  // const testRatio = nutzBalance && totalSupplyBabz && nutzBalance.toNumber() / totalSupplyBabz.toNumber();
   const pwrPercentage = pwrBalance && totalSupplyPwr && pwrBalance.div(totalSupplyPwr).mul(100).toFormat(6);
   const nutzPercentage = babzBalance && totalSupplyBabz && babzBalance.div(totalSupplyBabz).mul(100).toFormat(6);
   const ECONOMY_LIST = [
@@ -82,13 +81,11 @@ const Economy = (props) => {
     2: { textAlign: 'left', width: 10, whiteSpace: 'nowrap' },
   };
   return (
-    <div>
-      <List
-        items={ECONOMY_LIST}
-        headers={['', 'Nutz', 'Power']}
-        columnsStyle={COL_STYLE}
-      />
-    </div>
+    <List
+      items={ECONOMY_LIST}
+      headers={['', 'Nutz', 'Power']}
+      columnsStyle={COL_STYLE}
+    />
   );
 };
 Economy.propTypes = {

--- a/app/components/Dashboard/Overview.js
+++ b/app/components/Dashboard/Overview.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import messages from '../../containers/Dashboard/messages';
 import WithLoading from '../../components/WithLoading';
 import { formatEth } from '../../utils/amountFormatter';
 import { conf } from '../../app.config';
@@ -13,10 +12,11 @@ import List from '../List';
 import TimedButton from '../TimedButton';
 import Button from '../Button';
 
+import Economy from './Economy';
 import { Pane, SectionOverview, Subtitle } from './styles';
 
 const Overview = (props) => {
-  const { account, listTxns, downRequests, ethAllowance, ethPayoutDate, ethPayoutPending, handleETHPayout } = props;
+  const { account, listTxns, downRequests, ethAllowance, ethPayoutDate, ethPayoutPending, handleETHPayout, messages } = props;
   const requestColumnStyle = { width: 20, textAlign: 'left', whiteSpace: 'nowrap' };
   const emptyColumnStyle = { width: 20 };
   const ethAmount = formatEth(ethAllowance);
@@ -114,6 +114,11 @@ const Overview = (props) => {
         </SectionOverview>
       }
 
+      <SectionOverview name="economy">
+        <H2><FormattedMessage {...messages.economyTitle} /></H2>
+        <Economy {...props} />
+      </SectionOverview>
+
       <SectionOverview name="transaction-history">
         <H2><FormattedMessage {...messages.included} /></H2>
         <Subtitle>
@@ -153,6 +158,7 @@ Overview.propTypes = {
   ethPayoutPending: PropTypes.bool,
   ethPayoutDate: PropTypes.object,
   handleETHPayout: PropTypes.func,
+  messages: PropTypes.object,
   toggleInvestTour: PropTypes.func.isRequired,
 };
 

--- a/app/components/TransferDialog/PowerDown.js
+++ b/app/components/TransferDialog/PowerDown.js
@@ -12,17 +12,18 @@ import { Description } from './styles';
 const PowerDown = (props) => {
   const {
     messages,
-    totalSupply,
+    totalSupplyPwr,
     pwrBalance,
     handlePowerDown,
   } = props;
+  const minPowerDownPwr = totalSupplyPwr.div(10000).div(ABP_DECIMALS).ceil();
   return (
     <div>
       <Description>
         <FormattedHTMLMessage
           {...messages.powerDownDescr}
           values={{
-            min: totalSupply.div(10000).div(ABP_DECIMALS).ceil().toNumber(),
+            min: minPowerDownPwr,
           }}
         />
       </Description>
@@ -34,7 +35,7 @@ const PowerDown = (props) => {
         <TransferDialog
           handleTransfer={handlePowerDown}
           maxAmount={pwrBalance.div(ABP_DECIMALS)}
-          minAmount={totalSupply.div(10000).div(ABP_DECIMALS).ceil()}
+          minAmount={minPowerDownPwr}
           hideAddress
           label={<FormattedMessage {...messages.powerDownAmountLabel} />}
           amountUnit="ABP"
@@ -47,7 +48,7 @@ const PowerDown = (props) => {
 };
 PowerDown.propTypes = {
   messages: PropTypes.object.isRequired,
-  totalSupply: PropTypes.object.isRequired,
+  totalSupplyPwr: PropTypes.object.isRequired,
   handlePowerDown: PropTypes.func.isRequired,
   pwrBalance: PropTypes.object,
 };

--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -218,6 +218,7 @@ class DashboardRoot extends React.Component {
 
     this.power.downtime.call();
     this.power.totalSupply.call();
+    this.power.activeSupply.call();
     this.power.allEvents({
       toBlock: 'latest',
     }).watch((error, event) => {
@@ -233,6 +234,8 @@ class DashboardRoot extends React.Component {
   watchTokenEvents(proxyAddr) {
     this.token.floor.call();
     this.token.ceiling.call();
+    this.token.totalSupply.call();
+    this.token.activeSupply.call();
     this.token.balanceOf.call(proxyAddr);
     this.web3.eth.getBalance(proxyAddr);
 
@@ -424,7 +427,10 @@ class DashboardRoot extends React.Component {
     const { downRequests, isFishWarned } = this.state;
     const qrUrl = `ether:${account.proxy}`;
     const downtime = this.power.downtime();
-    const totalSupply = this.power.totalSupply();
+    const totalSupplyBabz = this.token.totalSupply();
+    const totalSupplyPwr = this.power.totalSupply();
+    const activeSupplyPwr = this.power.activeSupply();
+    const activeSupplyBabz = this.token.activeSupply();
     const weiBalance = this.web3.eth.balance(account.proxy);
     const ethBalance = weiBalance && weiBalance.div(ETH_DECIMALS);
     const babzBalance = this.token.balanceOf(account.proxy);
@@ -466,7 +472,10 @@ class DashboardRoot extends React.Component {
             ethPayoutPending: this.props.dashboardTxs.pendingETHPayout,
             pwrBalance,
             nutzBalance,
-            totalSupply,
+            totalSupplyPwr,
+            totalSupplyBabz,
+            activeSupplyPwr,
+            activeSupplyBabz,
             listTxns,
             qrUrl,
             messages,

--- a/app/containers/Dashboard/messages.js
+++ b/app/containers/Dashboard/messages.js
@@ -198,4 +198,32 @@ export default defineMessages({
     id: 'app.containers.Dashboard.upgradeAccount',
     defaultMessage: 'Unlock your Account',
   },
+  economyTitle: {
+    id: 'app.containers.Dashboard.economyTitle',
+    defaultMessage: 'Acebusters Economy',
+  },
+  economyListTotal: {
+    id: 'app.containers.Dashboard.economyListTotal',
+    defaultMessage: 'Total',
+  },
+  economyListActive: {
+    id: 'app.containers.Dashboard.economyListActive',
+    defaultMessage: 'Active',
+  },
+  economyListOwnership: {
+    id: 'app.containers.Dashboard.economyListOwnership',
+    defaultMessage: 'Your Ownership',
+  },
+  ntzUnit: {
+    id: 'app.containers.Dashboard.ntzUnit',
+    defaultMessage: '{amount} NTZ',
+  },
+  abpUnit: {
+    id: 'app.containers.Dashboard.abpUnit',
+    defaultMessage: '{amount} ABP',
+  },
+  percentUnit: {
+    id: 'app.containers.Dashboard.percentUnit',
+    defaultMessage: '{amount} %',
+  },
 });

--- a/app/utils/amountFormatter.js
+++ b/app/utils/amountFormatter.js
@@ -31,7 +31,7 @@ export function formatAmount(decimals, amount, dp) {
 export const toEth = toAmount.bind(null, ETH_DECIMALS);
 export const toNtz = toAmount.bind(null, NTZ_DECIMALS);
 export const formatNtz = (amount, dp = 0) => formatAmount(NTZ_DECIMALS, amount, dp);
-export const formatAbp = formatAmount.bind(null, ABP_DECIMALS);
+export const formatAbp = (amount, dp = 3) => formatAmount(ABP_DECIMALS, amount, dp);
 export const formatEth = formatAmount.bind(null, ETH_DECIMALS);
 
 // only allow digits and one dot


### PR DESCRIPTION
Show a table with all relevant stats related to NTZ and ABP supply, display percentage that users owns.

![image](https://user-images.githubusercontent.com/61939/30807413-ecc011a6-a223-11e7-8de3-dcd7a0c546ba.png)
