### PR TITLE
refactor(everything): Remove React.PropTypes and use 'prop-types' pac…

### DIFF
--- a/app/components/Alert/index.js
+++ b/app/components/Alert/index.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { gray } from '../../variables';
 

--- a/app/components/AmountField/index.js
+++ b/app/components/AmountField/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Field } from 'redux-form/immutable';
 import BigNumber from 'bignumber.js';
 

--- a/app/components/Blocky/index.js
+++ b/app/components/Blocky/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const Blocky = styled.div`
@@ -12,7 +12,7 @@ const Blocky = styled.div`
 `;
 
 Blocky.propTypes = {
-  blocky: React.PropTypes.string,
+  blocky: PropTypes.string,
 };
 
 export default Blocky;

--- a/app/components/Button/index.js
+++ b/app/components/Button/index.js
@@ -6,7 +6,8 @@
  * otherwise it'll render a link with an onclick
  */
 
-import React, { PropTypes, Children } from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import A from '../A';
 

--- a/app/components/Card/index.js
+++ b/app/components/Card/index.js
@@ -1,7 +1,5 @@
-/**
- * Created by helge on 24.08.16.
- */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { VectorCards } from 'ab-vector-cards';
 
 import { CardBack, CardFront, CardStyle } from '../Seat/styles';
@@ -47,9 +45,9 @@ function Card(props) {
 }
 
 Card.propTypes = {
-  cardNumber: React.PropTypes.number,
-  size: React.PropTypes.number,
-  folded: React.PropTypes.bool,
+  cardNumber: PropTypes.number,
+  size: PropTypes.number,
+  folded: PropTypes.bool,
 };
 
 export default Card;

--- a/app/components/FieldIntl/index.js
+++ b/app/components/FieldIntl/index.js
@@ -1,6 +1,7 @@
 /* eslint no-multi-spaces: "off", key-spacing: "off" */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Field } from 'redux-form/immutable';
 import { injectIntl } from 'react-intl';
 

--- a/app/components/Form/FormField.js
+++ b/app/components/Form/FormField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import FormGroup from './FormGroup';
 import Input from '../Input';
 import Label from '../Label';

--- a/app/components/FormMessages/index.js
+++ b/app/components/FormMessages/index.js
@@ -48,5 +48,5 @@ export function WarningMessage(props) {
 }
 
 WarningMessage.propTypes = {
-  warning: React.PropTypes.string,
+  warning: PropTypes.string,
 };

--- a/app/components/Header/Logo.js
+++ b/app/components/Header/Logo.js
@@ -1,5 +1,5 @@
-/* eslint-disable react/jsx-filename-extension */
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import {
@@ -50,10 +50,10 @@ const Logo = ({ href, logoLg, sidebarMini, collapse }) => (
     );
 
 Logo.propTypes = {
-  href: React.PropTypes.string,
-  logoLg: React.PropTypes.element,
-  sidebarMini: React.PropTypes.bool,
-  collapse: React.PropTypes.bool,
+  href: PropTypes.string,
+  logoLg: PropTypes.element,
+  sidebarMini: PropTypes.bool,
+  collapse: PropTypes.bool,
 };
 
 export default Logo;

--- a/app/components/Header/Navbar.js
+++ b/app/components/Header/Navbar.js
@@ -1,5 +1,5 @@
-/* eslint-disable react/jsx-filename-extension */
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import {
@@ -71,10 +71,10 @@ const Navbar = (props) => (
 
 
 Navbar.propTypes = {
-  children: React.PropTypes.node,
-  topNav: React.PropTypes.bool,
-  collapsed: React.PropTypes.bool,
-  loggedIn: React.PropTypes.bool,
+  children: PropTypes.node,
+  topNav: PropTypes.bool,
+  collapsed: PropTypes.bool,
+  loggedIn: PropTypes.bool,
 };
 
 export default Navbar;

--- a/app/components/Img/index.js
+++ b/app/components/Img/index.js
@@ -5,7 +5,8 @@
  * Renders an image, enforcing the usage of the alt="" tag
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function Img(props) {
   return (

--- a/app/components/IssueIcon/index.js
+++ b/app/components/IssueIcon/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function IssueIcon(props) {
   return (
@@ -13,7 +14,7 @@ function IssueIcon(props) {
 }
 
 IssueIcon.propTypes = {
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default IssueIcon;

--- a/app/components/List/index.js
+++ b/app/components/List/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import WithLoading from '../WithLoading';
 import ListItem from '../ListItem';

--- a/app/components/ListItem/index.js
+++ b/app/components/ListItem/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const Tr = styled.tr`
@@ -44,8 +45,8 @@ function ListItem({ values, columnsStyle = {} }) {
 }
 
 ListItem.propTypes = {
-  values: React.PropTypes.array,
-  columnsStyle: React.PropTypes.object,
+  values: PropTypes.array,
+  columnsStyle: PropTypes.object,
 };
 
 export default ListItem;

--- a/app/components/LoadingButton/index.js
+++ b/app/components/LoadingButton/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import LoadingIndicator from '../LoadingIndicator';
 
 function LoadingButton(props) {
@@ -11,7 +12,7 @@ function LoadingButton(props) {
 }
 
 LoadingButton.propTypes = {
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default LoadingButton;

--- a/app/components/LoadingIndicator/Circle.js
+++ b/app/components/LoadingIndicator/Circle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 
 const circleFadeDelay = keyframes`

--- a/app/components/MouseEntropy/index.js
+++ b/app/components/MouseEntropy/index.js
@@ -1,6 +1,6 @@
 /* eslint no-multi-spaces: "off", key-spacing: "off", jsx-a11y/no-static-element-interactions: "off" */
-
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { byEightDirection, throttleSync } from './sampling';
 import Bits from './bits';
@@ -140,11 +140,11 @@ class MouseEntropy extends React.Component {
 }
 
 MouseEntropy.propTypes = {
-  onFinish:   React.PropTypes.func.isRequired,
-  totalBits:  React.PropTypes.number.isRequired,
-  width:      React.PropTypes.string.isRequired,
-  height:     React.PropTypes.string.isRequired,
-  sampleRate: React.PropTypes.number.isRequired,
+  onFinish:   PropTypes.func.isRequired,
+  totalBits:  PropTypes.number.isRequired,
+  width:      PropTypes.string.isRequired,
+  height:     PropTypes.string.isRequired,
+  sampleRate: PropTypes.number.isRequired,
 };
 
 export default MouseEntropy;

--- a/app/components/Pot/index.js
+++ b/app/components/Pot/index.js
@@ -1,10 +1,5 @@
-/**
- * Copyright (c) 2017 Acebusters
- * Use of this source code is governed by an ISC
- * license that can be found in the LICENSE file.
-*/
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { chipValues, seatChipColor } from '../../app.config';
 import { white } from '../../variables';
@@ -112,10 +107,10 @@ function Pot(props) {
 }
 
 Pot.propTypes = {
-  potSize: React.PropTypes.number,
-  top: React.PropTypes.string,
-  left: React.PropTypes.string,
-  short: React.PropTypes.bool,
+  potSize: PropTypes.number,
+  top: PropTypes.string,
+  left: PropTypes.string,
+  short: PropTypes.bool,
 };
 
 export default Pot;

--- a/app/components/ProgressBar/ProgressBar.js
+++ b/app/components/ProgressBar/ProgressBar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Wrapper from './Wrapper';
 import Percent from './Percent';
 

--- a/app/components/ProgressBar/index.js
+++ b/app/components/ProgressBar/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ProgressBar from './ProgressBar';
 
 function withProgressBar(WrappedComponent) {
@@ -76,9 +77,9 @@ function withProgressBar(WrappedComponent) {
 
 
   AppWithProgressBar.propTypes = {
-    location: React.PropTypes.object,
-    router: React.PropTypes.object,
-    progress: React.PropTypes.number,
+    location: PropTypes.object,
+    router: PropTypes.object,
+    progress: PropTypes.number,
   };
 
   return AppWithProgressBar;

--- a/app/components/RadialProgress/index.js
+++ b/app/components/RadialProgress/index.js
@@ -1,5 +1,6 @@
 /* eslint react/prop-types: 0 */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import enhancer from './enhancer';
 
@@ -104,16 +105,16 @@ class Radial extends Component {
 }
 
 Radial.PropTypes = {
-  className: React.PropTypes.string,
-  percent: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
-  prefixCls: React.PropTypes.string,
-  strokeColor: React.PropTypes.string,
-  strokeLinecap: React.PropTypes.oneOf(['round', 'square']),
-  strokeWidth: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
-  style: React.PropTypes.object,
-  trailColor: React.PropTypes.string,
-  trailWidth: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
-  gapPosition: React.PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
+  className: PropTypes.string,
+  percent: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  prefixCls: PropTypes.string,
+  strokeColor: PropTypes.string,
+  strokeLinecap: PropTypes.oneOf(['round', 'square']),
+  strokeWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  style: PropTypes.object,
+  trailColor: PropTypes.string,
+  trailWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  gapPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
 };
 
 Radial.defaultProps = {

--- a/app/components/Seat/ButtonInvite.js
+++ b/app/components/Seat/ButtonInvite.js
@@ -1,8 +1,6 @@
-/**
-* Created by jzobro 20170519
-*/
 /* Replaced by ButtonOpenSeat until Invite process is complete */
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   ButtonIcon,
   ButtonStyle,
@@ -22,8 +20,8 @@ const ButtonInvite = ({ coords, onClickHandler }) => (
   </SeatWrapper>
 );
 ButtonInvite.propTypes = {
-  onClickHandler: React.PropTypes.func,
-  coords: React.PropTypes.array,
+  onClickHandler: PropTypes.func,
+  coords: PropTypes.array,
 };
 
 export default ButtonInvite;

--- a/app/components/Seat/ButtonJoinSeat.js
+++ b/app/components/Seat/ButtonJoinSeat.js
@@ -1,7 +1,5 @@
-/**
-* Created by jzobro 20170518
-*/
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   ButtonIcon,
   ButtonStyle,
@@ -22,8 +20,8 @@ const ButtonJoinSeat = ({ coords, onClickHandler }) => (
 );
 
 ButtonJoinSeat.propTypes = {
-  coords: React.PropTypes.array,
-  onClickHandler: React.PropTypes.func,
+  coords: PropTypes.array,
+  onClickHandler: PropTypes.func,
 };
 
 export default ButtonJoinSeat;

--- a/app/components/Seat/CardsComponent.js
+++ b/app/components/Seat/CardsComponent.js
@@ -1,7 +1,5 @@
-/**
-* Created by jzobro 20170524
-*/
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Card from '../Card';
 
@@ -30,8 +28,8 @@ const CardsComponent = ({
   </CardContainer>
 );
 CardsComponent.propTypes = {
-  folded: React.PropTypes.bool,
-  holeCards: React.PropTypes.array, // array of cards
+  folded: PropTypes.bool,
+  holeCards: PropTypes.array, // array of cards
 };
 
 export default CardsComponent;

--- a/app/components/Seat/Seat.js
+++ b/app/components/Seat/Seat.js
@@ -1,7 +1,5 @@
-/**
-* Created by jzobro 20170520
-*/
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import CardsComponent from './CardsComponent';
 import SeatInfo from './SeatInfo';
@@ -45,10 +43,10 @@ const Seat = (props) => {
   );
 };
 Seat.propTypes = {
-  myPos: React.PropTypes.number,
-  pos: React.PropTypes.number,
-  coords: React.PropTypes.array,
-  seatStatus: React.PropTypes.object,
+  myPos: PropTypes.number,
+  pos: PropTypes.number,
+  coords: PropTypes.array,
+  seatStatus: PropTypes.object,
 };
 
 export default Seat;

--- a/app/components/Seat/SeatInfo.js
+++ b/app/components/Seat/SeatInfo.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Pot from '../Pot';
 import { nickNameByAddress } from '../../services/nicknames';
@@ -53,14 +54,14 @@ const SeatInfo = ({
 );
 
 SeatInfo.propTypes = {
-  amountCoords: React.PropTypes.array,
-  blocky: React.PropTypes.string,
-  dealer: React.PropTypes.number, // which seat is dealer
-  lastAmount: React.PropTypes.number,
-  pos: React.PropTypes.number, // which position is THIS seat
-  signerAddr: React.PropTypes.string,
-  seatStatus: React.PropTypes.object,
-  stackSize: React.PropTypes.number,
+  amountCoords: PropTypes.array,
+  blocky: PropTypes.string,
+  dealer: PropTypes.number, // which seat is dealer
+  lastAmount: PropTypes.number,
+  pos: PropTypes.number, // which position is THIS seat
+  signerAddr: PropTypes.string,
+  seatStatus: PropTypes.object,
+  stackSize: PropTypes.number,
 };
 
 export default SeatInfo;

--- a/app/components/Seat/SeatTimer.js
+++ b/app/components/Seat/SeatTimer.js
@@ -1,7 +1,5 @@
-/**
-* Created by jzobro 20170519
-*/
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   TimerBackground,
@@ -28,7 +26,7 @@ const SeatTimer = ({ timeLeft }) => (
 );
 
 SeatTimer.propTypes = {
-  timeLeft: React.PropTypes.number,
+  timeLeft: PropTypes.number,
 };
 
 export default SeatTimer;

--- a/app/components/Seat/SitoutTimer.js
+++ b/app/components/Seat/SitoutTimer.js
@@ -1,7 +1,5 @@
-/**
-* Created by jzobro 20170519
-*/
 import React from 'react';
+// import PropTypes from 'prop-types';
 
 import {
   TimerBackground,
@@ -21,7 +19,7 @@ const SitoutTimer = () => (
 );
 
 SitoutTimer.propTypes = {
-  // sitout: React.PropTypes.number,
+  // sitout: PropTypes.number,
 };
 
 export default SitoutTimer;

--- a/app/components/Seat/StatusAction.js
+++ b/app/components/Seat/StatusAction.js
@@ -1,7 +1,5 @@
-/**
-* Created by jzobro 20170520
-*/
 import React from 'react';
+import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 
 import SeatTimer from './SeatTimer';
@@ -44,15 +42,15 @@ const StatusAction = ({
   return null;
 };
 StatusAction.propTypes = {
-  pos: React.PropTypes.number,
-  showStatus: React.PropTypes.object,
-  sitout: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number,
+  pos: PropTypes.number,
+  showStatus: PropTypes.object,
+  sitout: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
   ]),
-  timeLeft: React.PropTypes.number,
-  wasMostRecentAction: React.PropTypes.bool,
-  whosTurn: React.PropTypes.number,
+  timeLeft: PropTypes.number,
+  wasMostRecentAction: PropTypes.bool,
+  whosTurn: PropTypes.number,
 };
 
 export default StatusAction;

--- a/app/components/Seat/tests/SeatTimer.test.js
+++ b/app/components/Seat/tests/SeatTimer.test.js
@@ -1,12 +1,9 @@
-/**
-* Created by jzobro 20170524
-*/
 import React from 'react';
 import { shallow } from 'enzyme';
 import SeatTimer from '../SeatTimer';
 
-// timerProgress: React.PropTypes.number,
-// timerType: React.PropTypes.string, // sitout or action
+// timerProgress: PropTypes.number,
+// timerType: PropTypes.string, // sitout or action
 
 describe('components.seat.SeatTimer', () => {
   describe('sitout timer', () => {

--- a/app/components/Slider/index.js
+++ b/app/components/Slider/index.js
@@ -47,8 +47,8 @@ const handle = (props) => {
   );
 };
 handle.propTypes = {
-  value: React.PropTypes.number,
-  dragging: React.PropTypes.bool,
+  value: PropTypes.number,
+  dragging: PropTypes.bool,
 };
 
 const Slider = (props) => (

--- a/app/components/Slides/index.js
+++ b/app/components/Slides/index.js
@@ -1,5 +1,5 @@
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const boxSizing = 'box-sizing: content-box;';
@@ -161,17 +161,17 @@ class Slides extends React.Component {
 }
 
 Slides.propTypes = {
-  children: React.PropTypes.array.isRequired,
-  width: React.PropTypes.number.isRequired,
-  height: React.PropTypes.number.isRequired,
-  SlidesWrapperComponent: React.PropTypes.instanceOf(React.Component),
-  SlideBoxComponent: React.PropTypes.instanceOf(React.Component),
-  SlidesOuterComponent: React.PropTypes.instanceOf(React.Component),
-  SlidesInnerComponent: React.PropTypes.instanceOf(React.Component),
-  SlideLeftComponent: React.PropTypes.instanceOf(React.Component),
-  SlideRightComponent: React.PropTypes.instanceOf(React.Component),
-  DotBoxComponent: React.PropTypes.instanceOf(React.Component),
-  DotComponent: React.PropTypes.instanceOf(React.Component),
+  children: PropTypes.array.isRequired,
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  SlidesWrapperComponent: PropTypes.instanceOf(React.Component),
+  SlideBoxComponent: PropTypes.instanceOf(React.Component),
+  SlidesOuterComponent: PropTypes.instanceOf(React.Component),
+  SlidesInnerComponent: PropTypes.instanceOf(React.Component),
+  SlideLeftComponent: PropTypes.instanceOf(React.Component),
+  SlideRightComponent: PropTypes.instanceOf(React.Component),
+  DotBoxComponent: PropTypes.instanceOf(React.Component),
+  DotComponent: PropTypes.instanceOf(React.Component),
 };
 
 export default Slides;

--- a/app/components/Table/index.js
+++ b/app/components/Table/index.js
@@ -1,7 +1,3 @@
-/**
- * Created by helge on 14.02.17.
- */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Board } from './Board';
@@ -64,7 +60,7 @@ const TableComponent = (props) => (
 );
 
 Seats.propTypes = {
-  seats: React.PropTypes.array,
+  seats: PropTypes.array,
 };
 
 TableComponent.propTypes = {

--- a/app/components/Toggle/index.js
+++ b/app/components/Toggle/index.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Select from './Select';
 import ToggleOption from '../ToggleOption';
@@ -27,10 +28,10 @@ function Toggle(props) {
 }
 
 Toggle.propTypes = {
-  onToggle: React.PropTypes.func,
-  values: React.PropTypes.array,
-  value: React.PropTypes.string,
-  messages: React.PropTypes.object,
+  onToggle: PropTypes.func,
+  values: PropTypes.array,
+  value: PropTypes.string,
+  messages: PropTypes.object,
 };
 
 export default Toggle;

--- a/app/components/ToggleOption/index.js
+++ b/app/components/ToggleOption/index.js
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 
 const ToggleOption = ({ value, message, intl }) => (
@@ -14,8 +15,8 @@ const ToggleOption = ({ value, message, intl }) => (
 );
 
 ToggleOption.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  message: React.PropTypes.object,
+  value: PropTypes.string.isRequired,
+  message: PropTypes.object,
   intl: intlShape.isRequired,
 };
 

--- a/app/components/WithLoading/index.js
+++ b/app/components/WithLoading/index.js
@@ -1,6 +1,6 @@
 /* eslint no-multi-spaces: "off", key-spacing: "off" */
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { keyframes } from 'styled-components';
 
 const spinnerAnimation = keyframes`
@@ -78,11 +78,11 @@ const WithLoading = ({ children, isLoading, loadingSize, type = 'block', styles 
 };
 
 WithLoading.propTypes = {
-  children: React.PropTypes.node,
-  isLoading:  React.PropTypes.bool.isRequired,
-  loadingSize: React.PropTypes.string,
-  type:  React.PropTypes.string,
-  styles:  React.PropTypes.object,
+  children: PropTypes.node,
+  isLoading:  PropTypes.bool.isRequired,
+  loadingSize: PropTypes.string,
+  type:  PropTypes.string,
+  styles:  PropTypes.object,
 };
 
 export default WithLoading;

--- a/app/containers/AccountProvider/index.js
+++ b/app/containers/AccountProvider/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
@@ -11,7 +12,7 @@ import { web3Connect, clearWeb3Error } from './actions';
 import { modalAdd, modalDismiss } from '../App/actions';
 import SubmitButton from '../../components/SubmitButton';
 
-export class AccountProvider extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+export class AccountProvider extends React.PureComponent {
   componentDidMount() {
     this.props.web3Connect(); // initiate web3
   }
@@ -52,16 +53,16 @@ export class AccountProvider extends React.PureComponent { // eslint-disable-lin
 }
 
 AccountProvider.propTypes = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.node),
-    React.PropTypes.node,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
   ]),
-  web3Connect: React.PropTypes.func,
-  web3ErrMsg: React.PropTypes.string,
-  isWeb3Connected: React.PropTypes.bool,
-  clearWeb3Error: React.PropTypes.func,
-  modalAdd: React.PropTypes.func,
-  modalDismiss: React.PropTypes.func,
+  web3Connect: PropTypes.func,
+  web3ErrMsg: PropTypes.string,
+  isWeb3Connected: PropTypes.bool,
+  clearWeb3Error: PropTypes.func,
+  modalAdd: PropTypes.func,
+  modalDismiss: PropTypes.func,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/ActionBar/index.js
+++ b/app/containers/ActionBar/index.js
@@ -1,6 +1,3 @@
-/**
- * Created by helge on 24.08.16.
- */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Raven from 'raven-js';
@@ -292,8 +289,8 @@ ActionBarContainer.propTypes = {
   mode: PropTypes.string,
   updateActionBar: PropTypes.func,
   canICheck: PropTypes.bool,
-  isMyTurn: React.PropTypes.bool,
-  hand: React.PropTypes.object,
+  isMyTurn: PropTypes.bool,
+  hand: PropTypes.object,
 };
 
 export function mapDispatchToProps(dispatch) {

--- a/app/containers/GTM/index.js
+++ b/app/containers/GTM/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class GoogleTagManager extends React.PureComponent {
   componentDidMount() {
@@ -33,9 +34,9 @@ class GoogleTagManager extends React.PureComponent {
 }
 
 GoogleTagManager.propTypes = {
-  gtmId: React.PropTypes.string.isRequired,
-  dataLayerName: React.PropTypes.string,
-  additionalEvents: React.PropTypes.object,
+  gtmId: PropTypes.string.isRequired,
+  dataLayerName: PropTypes.string,
+  additionalEvents: PropTypes.object,
 };
 
 export default GoogleTagManager;

--- a/app/containers/InviteDialog/index.js
+++ b/app/containers/InviteDialog/index.js
@@ -1,9 +1,5 @@
-/**
- * Created by helge on 10.03.17.
- */
-
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Form, Field, reduxForm } from 'redux-form/immutable';
 import { FormattedMessage } from 'react-intl';

--- a/app/containers/LanguageProvider/index.js
+++ b/app/containers/LanguageProvider/index.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { IntlProvider } from 'react-intl';
@@ -24,9 +25,9 @@ export class LanguageProvider extends React.PureComponent { // eslint-disable-li
 }
 
 LanguageProvider.propTypes = {
-  locale: React.PropTypes.string,
-  messages: React.PropTypes.object,
-  children: React.PropTypes.element.isRequired,
+  locale: PropTypes.string,
+  messages: PropTypes.object,
+  children: PropTypes.element.isRequired,
 };
 
 const mapStateToProps = createSelector(

--- a/app/containers/LobbyItem/index.js
+++ b/app/containers/LobbyItem/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { createStructuredSelector } from 'reselect';
@@ -58,9 +59,9 @@ class LobbyItem extends React.PureComponent { // eslint-disable-line
 }
 
 LobbyItem.propTypes = {
-  tableAddr: React.PropTypes.string,
-  data: React.PropTypes.object,
-  lastHandId: React.PropTypes.number,
+  tableAddr: PropTypes.string,
+  data: PropTypes.object,
+  lastHandId: PropTypes.number,
 };
 
 const mapStateToProps = createStructuredSelector({

--- a/app/containers/LocaleToggle/index.js
+++ b/app/containers/LocaleToggle/index.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
@@ -26,8 +27,8 @@ export class LocaleToggle extends React.PureComponent { // eslint-disable-line r
 }
 
 LocaleToggle.propTypes = {
-  onLocaleToggle: React.PropTypes.func,
-  locale: React.PropTypes.string,
+  onLocaleToggle: PropTypes.func,
+  locale: PropTypes.string,
 };
 
 const mapStateToProps = createSelector(

--- a/app/containers/LoginPage/index.js
+++ b/app/containers/LoginPage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
 import { Form, Field, reduxForm, SubmissionError, propTypes } from 'redux-form/immutable';
@@ -173,11 +174,11 @@ export class LoginPage extends React.PureComponent { // eslint-disable-line reac
 
 LoginPage.propTypes = {
   ...propTypes,
-  location: React.PropTypes.any,
-  setProgress: React.PropTypes.func,
-  walletImport: React.PropTypes.func,
-  setAuthState: React.PropTypes.func,
-  notifyAdd: React.PropTypes.func,
+  location: PropTypes.any,
+  setProgress: PropTypes.func,
+  walletImport: PropTypes.func,
+  setAuthState: PropTypes.func,
+  notifyAdd: PropTypes.func,
 };
 
 

--- a/app/containers/LoginProgressModal/index.js
+++ b/app/containers/LoginProgressModal/index.js
@@ -1,8 +1,5 @@
-/**
- * Created by helge on 09.03.17.
- */
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { formValueSelector } from 'redux-form/immutable';
 import Radial from '../../components/RadialProgress';
@@ -17,7 +14,7 @@ export function LoginProgressWrapper(props) {
 }
 
 LoginProgressWrapper.propTypes = {
-  progress: React.PropTypes.any,
+  progress: PropTypes.any,
 };
 
 const selector = formValueSelector('login');

--- a/app/containers/RegisterPage/captcha.js
+++ b/app/containers/RegisterPage/captcha.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReCAPTCHA from 'react-google-recaptcha';
 import { conf } from '../../app.config';
 
@@ -27,6 +28,6 @@ export default class Captcha extends React.Component { // eslint-disable-line re
 }
 
 Captcha.propTypes = {
-  error: React.PropTypes.any,
-  input: React.PropTypes.any,
+  error: PropTypes.any,
+  input: PropTypes.any,
 };

--- a/app/containers/RegisterPage/index.js
+++ b/app/containers/RegisterPage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Form, Field, reduxForm, propTypes, formValueSelector } from 'redux-form/immutable';
 import { FormattedMessage } from 'react-intl';
@@ -120,8 +121,8 @@ export class RegisterPage extends React.Component { // eslint-disable-line react
 
 RegisterPage.propTypes = {
   ...propTypes,
-  input: React.PropTypes.any,
-  defaultRefCode: React.PropTypes.string,
+  input: PropTypes.any,
+  defaultRefCode: PropTypes.string,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/ResetPage/index.js
+++ b/app/containers/ResetPage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import ReCAPTCHA from 'react-google-recaptcha';
 import { Form, Field, reduxForm, SubmissionError, propTypes } from 'redux-form/immutable';
@@ -98,7 +99,7 @@ export class ResetPage extends React.Component { // eslint-disable-line react/pr
 
 ResetPage.propTypes = {
   ...propTypes,
-  input: React.PropTypes.any,
+  input: PropTypes.any,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/Seat/index.js
+++ b/app/containers/Seat/index.js
@@ -1,7 +1,5 @@
-/**
- * Created by helge on 24.08.16.
- */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
@@ -123,10 +121,10 @@ const mapStateToProps = createStructuredSelector({
 });
 
 Seat.propTypes = {
-  lastAmount: React.PropTypes.number,
-  changed: React.PropTypes.number,
-  whosTurn: React.PropTypes.number,
-  pos: React.PropTypes.number,
+  lastAmount: PropTypes.number,
+  changed: PropTypes.number,
+  whosTurn: PropTypes.number,
+  pos: PropTypes.number,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Seat);

--- a/app/containers/Table/index.js
+++ b/app/containers/Table/index.js
@@ -1,8 +1,5 @@
-/**
- * Created by helge on 24.08.16.
- */
-// react + redux
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { createStructuredSelector } from 'reselect';
 import { browserHistory } from 'react-router';
@@ -615,44 +612,44 @@ const mapStateToProps = createStructuredSelector({
 });
 
 Table.propTypes = {
-  state: React.PropTypes.string,
-  board: React.PropTypes.array,
-  hand: React.PropTypes.object,
-  isMyTurn: React.PropTypes.bool,
-  myHand: React.PropTypes.object,
-  myStack: React.PropTypes.number,
-  lineup: React.PropTypes.object,
-  sitout: React.PropTypes.any,
-  params: React.PropTypes.object,
-  privKey: React.PropTypes.string,
-  lastReceipt: React.PropTypes.string,
-  latestHand: React.PropTypes.any,
-  sitoutAmount: React.PropTypes.number,
-  standingUp: React.PropTypes.bool,
-  proxyAddr: React.PropTypes.string,
-  signerAddr: React.PropTypes.string,
-  web3Redux: React.PropTypes.any,
-  data: React.PropTypes.any,
-  myPos: React.PropTypes.any,
-  potSize: React.PropTypes.number,
-  modalAdd: React.PropTypes.func,
-  setPending: React.PropTypes.func,
-  setExitHand: React.PropTypes.func,
-  modalDismiss: React.PropTypes.func,
-  reserveSeat: React.PropTypes.func,
-  winners: React.PropTypes.array,
-  dispatch: React.PropTypes.func,
-  lineupReceived: React.PropTypes.func,
-  reservationReceived: React.PropTypes.func, // eslint-disable-line react/no-unused-prop-types
-  seatReserved: React.PropTypes.func,
-  seatsReleased: React.PropTypes.func,
-  updateReceived: React.PropTypes.func,
-  loadTable: React.PropTypes.func,
-  addMessage: React.PropTypes.func,
-  location: React.PropTypes.object,
-  account: React.PropTypes.object,
-  myPendingSeat: React.PropTypes.number,
-  tableLoadingState: React.PropTypes.string,
+  state: PropTypes.string,
+  board: PropTypes.array,
+  hand: PropTypes.object,
+  isMyTurn: PropTypes.bool,
+  myHand: PropTypes.object,
+  myStack: PropTypes.number,
+  lineup: PropTypes.object,
+  sitout: PropTypes.any,
+  params: PropTypes.object,
+  privKey: PropTypes.string,
+  lastReceipt: PropTypes.string,
+  latestHand: PropTypes.any,
+  sitoutAmount: PropTypes.number,
+  standingUp: PropTypes.bool,
+  proxyAddr: PropTypes.string,
+  signerAddr: PropTypes.string,
+  web3Redux: PropTypes.any,
+  data: PropTypes.any,
+  myPos: PropTypes.any,
+  potSize: PropTypes.number,
+  modalAdd: PropTypes.func,
+  setPending: PropTypes.func,
+  setExitHand: PropTypes.func,
+  modalDismiss: PropTypes.func,
+  reserveSeat: PropTypes.func,
+  winners: PropTypes.array,
+  dispatch: PropTypes.func,
+  lineupReceived: PropTypes.func,
+  reservationReceived: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
+  seatReserved: PropTypes.func,
+  seatsReleased: PropTypes.func,
+  updateReceived: PropTypes.func,
+  loadTable: PropTypes.func,
+  addMessage: PropTypes.func,
+  location: PropTypes.object,
+  account: PropTypes.object,
+  myPendingSeat: PropTypes.number,
+  tableLoadingState: PropTypes.string,
 };
 
 

--- a/app/containers/TableMenu/index.js
+++ b/app/containers/TableMenu/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { browserHistory } from 'react-router';
@@ -34,7 +35,7 @@ const TableMenuContainer = (props) => (
   />
 );
 TableMenuContainer.propTypes = {
-  open: React.PropTypes.bool,
+  open: PropTypes.bool,
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/internals/templates/containers/App/index.js
+++ b/internals/templates/containers/App/index.js
@@ -12,11 +12,12 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class App extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
 
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
   };
 
   render() {

--- a/internals/templates/containers/LanguageProvider/index.js
+++ b/internals/templates/containers/LanguageProvider/index.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { IntlProvider } from 'react-intl';
@@ -24,9 +25,9 @@ export class LanguageProvider extends React.PureComponent { // eslint-disable-li
 }
 
 LanguageProvider.propTypes = {
-  locale: React.PropTypes.string,
-  messages: React.PropTypes.object,
-  children: React.PropTypes.element.isRequired,
+  locale: PropTypes.string,
+  messages: PropTypes.object,
+  children: PropTypes.element.isRequired,
 };
 
 


### PR DESCRIPTION
…kage

Was getting sick of seeing the PropTypes warning in the console. However, after removing all React.PropType's it still is throwing. So it is probably still used in some of the dependencies.