### PR TITLE
Fix broken styles on dashboard when you going from lobby page

### DIFF
--- a/app/containers/LobbyItem/index.js
+++ b/app/containers/LobbyItem/index.js
@@ -49,9 +49,9 @@ class LobbyItem extends React.PureComponent { // eslint-disable-line
           <Link
             to={`/table/${this.props.tableAddr}`}
             size="small"
-            icon="fa fa-eye"
-            component={Button}
-          />
+          >
+            <Button icon="fa fa-eye" />
+          </Link>
         </Td>
       </Tr>
     );

--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "redux-saga": "^0.14.2",
     "reselect": "2.5.4",
     "sanitize.css": "4.1.0",
-    "styled-components": "^2.1.0",
+    "styled-components": "^2.2.1",
     "tinycolor2": "^1.4.1",
     "uuid": "^3.0.1",
     "warning": "3.0.0",


### PR DESCRIPTION
Fixes #756

Looks like `styled-components` doesn't like this branch https://github.com/acebusters/ab-web/blob/develop/app/components/Button/index.js#L140. Maybe I'll try to find the bug in `styled-components` later.

Also updated `styled-components` to the latest version.