### PR TITLE
Feat/deposit modal

### DIFF
--- a/app/components/Dashboard/DepositInfo.js
+++ b/app/components/Dashboard/DepositInfo.js
@@ -13,10 +13,13 @@ import Button from '../Button';
 
 class DepositInfo extends React.Component {
   static propTypes = {
-    account: PropTypes.object.isRequired,
+    account: PropTypes.shape({ isLocked: PropTypes.bool }),
     isFishWarned: PropTypes.bool.isRequired,
     modalAdd: PropTypes.func.isRequired,
   };
+  static defaultProps = {
+    account: { isLocked: true },
+  }
 
   constructor(props) {
     super(props);
@@ -25,7 +28,8 @@ class DepositInfo extends React.Component {
   }
 
   handleClick() {
-    if (!this.props.isFishWarned) {
+    const { isFishWarned, account: { isLocked } } = this.props;
+    if (!isFishWarned && isLocked) {
       return this.props.modalAdd({
         modalType: FISH_WARNING_DIALOG,
         modalProps: {

--- a/app/components/Dashboard/DepositInfo.js
+++ b/app/components/Dashboard/DepositInfo.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+import QRCode from 'qrcode.react';
+import ethUtil from 'ethereumjs-util';
+import makeSelectAccountData from 'containers/AccountProvider/selectors';
+import { FISH_WARNING_DIALOG } from 'containers/Modal/constants';
+import { modalAdd, modalDismiss } from 'containers/App/actions';
+import { createIsFishWarnedSelector } from 'containers/Dashboard/selectors';
+import { setFishWarned } from 'containers/Dashboard/actions';
+import Alert from '../Alert';
+import Button from '../Button';
+import WithLoading from '../WithLoading';
+
+import { Address } from './styles';
+/* eslint-disable react/prefer-stateless-function */
+class DepositInfo extends React.Component {
+  static propTypes = {
+    account: PropTypes.object.isRequired,
+    isFishWarned: PropTypes.bool.isRequired,
+    setFishWarned: PropTypes.func.isRequired,
+    modalAdd: PropTypes.func.isRequired,
+    modalDismiss: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const { account, isFishWarned } = this.props;
+    const qrUrl = `ether:${account.proxy}`;
+    const qrStyles = isFishWarned
+      ? { margin: 'auto' }
+    : { margin: 'auto', filter: 'blur(4px)', opacity: '.5' };
+    const handleClick = () => this.props.modalAdd({
+      modalType: FISH_WARNING_DIALOG,
+      modalProps: {
+        onSuccessButtonClick: () => {
+          this.props.modalDismiss();
+          this.props.setFishWarned();
+        },
+      },
+    });
+    return (
+      <div>
+        <WithLoading
+          isLoading={!account.proxy || account.proxy === '0x'}
+          loadingSize="40px"
+          styles={{
+            outer: qrStyles,
+          }}
+        >
+          <QRCode value={qrUrl} size={100} />
+          <Alert style={qrStyles} theme="success">
+            <Address style={{ width: 180 }}>
+              {ethUtil.toChecksumAddress(account.proxy)}
+            </Address>
+          </Alert>
+        </WithLoading>
+        {!isFishWarned &&
+          <Button
+            style={{ position: 'relative', top: -120 }}
+            onClick={handleClick}
+            size="medium"
+          >
+            Deposit
+          </Button>
+        }
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createStructuredSelector({
+  account: makeSelectAccountData(),
+  isFishWarned: createIsFishWarnedSelector(),
+});
+
+export default connect(
+  mapStateToProps,
+  { modalAdd, modalDismiss, setFishWarned },
+)(DepositInfo);

--- a/app/components/Dashboard/SectionReceive.js
+++ b/app/components/Dashboard/SectionReceive.js
@@ -1,25 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import QRCode from 'qrcode.react';
 import ethUtil from 'ethereumjs-util';
 import { FormattedMessage } from 'react-intl';
 
 import BtnUpgrade from 'containers/Button/BtnUpgrade';
-import { FISH_WARNING_DIALOG } from 'containers/Modal/constants';
 import messages from '../../containers/Dashboard/messages';
 import AccountProgress from '../../containers/Dashboard/AccountProgress';
-import WithLoading from '../WithLoading';
 import { MAIN_NET_GENESIS_BLOCK, ETH_FISH_LIMIT, conf } from '../../app.config';
 import shapeshiftButton from './shapeshift.png';
 
 import Alert from '../Alert';
 
+import DepositInfo from './DepositInfo';
 import {
-  Address,
   ReceiveWrapper,
   ReceiveSection,
 } from './styles';
-import Button from '../Button';
 
 function handleShapeshiftClick(e) {
   e.preventDefault();
@@ -28,96 +24,37 @@ function handleShapeshiftClick(e) {
 
 const shapeShiftLink = (proxy) => `https://shapeshift.io/shifty.html?destination=${proxy}&output=ETH&apiKey=${conf().shapeshiftKey}`;
 
-export const AccountIsLocked = (props) => {
+export const SectionReceive = (props) => {
   const {
     account,
     ethBalance,
     nutzBalance,
     floor,
-    qrUrl,
-    modalAdd,
-    modalDismiss,
-    isFishWarned,
-    fishWarn,
   } = props;
-  const qrStyles = isFishWarned
-    ? { margin: 'auto' }
-    : { margin: 'auto', filter: 'blur(4px)', opacity: '.4' };
   return (
     <ReceiveSection>
-      <ReceiveWrapper
-        style={{
-          margin: '12px 10px',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        {!isFishWarned &&
-          <span style={{ position: 'relative' }}>
-            <span
-              style={{
-                position: 'absolute',
-                zIndex: '1',
-                textAlign: 'center',
-                top: '70px',
-                width: '100%',
-              }}
-            >
-              <Button
-                size="small"
-                onClick={() => modalAdd({
-                  modalType: FISH_WARNING_DIALOG,
-                  modalProps: {
-                    onSuccessButtonClick: () => {
-                      modalDismiss();
-                      fishWarn();
-                    },
-                  },
-                })}
-              >
-                Deposit
-              </Button>
-            </span>
-          </span>
-        }
-        <WithLoading
-          isLoading={!account.proxy || account.proxy === '0x'}
-          loadingSize="40px"
-          styles={{
-            layout: { transform: 'translateY(-50%)', left: 0 },
-            outer: qrStyles,
-          }}
-        >
-          <QRCode value={qrUrl} size={100} />
-        </WithLoading>
-        {isFishWarned &&
-          <WithLoading
-            isLoading={!account.proxy || account.proxy === '0x'}
-            loadingSize="40px"
-            styles={{
-              layout: { transform: 'translateY(-50%)', left: 0 },
-              outer: { marginTop: 'auto' },
-            }}
-          >
-            <Alert theme="success" data-tour="wallet-address">
-              <Address style={{ width: 180 }}>{ethUtil.toChecksumAddress(account.proxy)}</Address>
-            </Alert>
-          </WithLoading>
-        }
-      </ReceiveWrapper>
-
       <ReceiveWrapper>
+        <DepositInfo data-tour="wallet-address" />
+
+        {conf().firstBlockHash === MAIN_NET_GENESIS_BLOCK &&
+          <a
+            onClick={handleShapeshiftClick}
+            href={shapeShiftLink(ethUtil.toChecksumAddress(account.proxy))}
+          >
+            <img src={shapeshiftButton} alt="Pay with Shapeshift" />
+          </a>
+        }
+
         {conf().firstBlockHash !== MAIN_NET_GENESIS_BLOCK &&
           <Alert theme="danger">
             <FormattedMessage {...messages.ethAlert} />
           </Alert>
         }
-
         <Alert theme="warning">
           Please note you´ll need some amount of ETH in your MetaMask wallet if you want to unlock account and pay transaction fees after unlock (table joins, transfers etc). Depending on the gas price you will need to pay ≈0.004 ETH to join the table.
         </Alert>
 
-        {ethBalance && nutzBalance && floor &&
+        {account.isLocked && ethBalance && nutzBalance && floor &&
           <Alert theme="warning" data-tour="wallet-unlock">
             <FormattedMessage values={{ limit: ETH_FISH_LIMIT.toString() }} {...messages.ethLimit} />
             <BtnUpgrade {...{ account, messages }} />
@@ -133,71 +70,11 @@ export const AccountIsLocked = (props) => {
     </ReceiveSection>
   );
 };
-AccountIsLocked.propTypes = {
+SectionReceive.propTypes = {
   account: PropTypes.object,
   ethBalance: PropTypes.object,
   nutzBalance: PropTypes.object,
   floor: PropTypes.object,
-  qrUrl: PropTypes.string,
-  modalAdd: PropTypes.func.isRequired,
-  modalDismiss: PropTypes.func.isRequired,
-  isFishWarned: PropTypes.bool,
-  fishWarn: PropTypes.func.isRequired,
 };
 
-export const AccountNotLocked = ({
-  account,
-  qrUrl,
-}) => (
-  <ReceiveSection>
-    <ReceiveWrapper
-      style={{
-        alignSelf: 'flex-start',
-        margin: '0 12px',
-      }}
-    >
-      <WithLoading
-        isLoading={!account.proxy || account.proxy === '0x'}
-        loadingSize="40px"
-        styles={{ layout: { transform: 'translateY(-50%)', left: 0 } }}
-      >
-        <QRCode
-          value={qrUrl}
-          size={100}
-        />
-      </WithLoading>
-    </ReceiveWrapper>
-
-    <ReceiveWrapper>
-      <Alert
-        style={{ marginTop: 0, marginBottom: 10 }}
-        theme="success"
-        data-tour="wallet-address"
-      >
-        <Address>{ethUtil.toChecksumAddress(account.proxy)}</Address>
-      </Alert>
-      {conf().firstBlockHash !== MAIN_NET_GENESIS_BLOCK &&
-        <Alert theme="danger">
-          <FormattedMessage {...messages.ethAlert} />
-        </Alert>
-      }
-
-      {conf().firstBlockHash === MAIN_NET_GENESIS_BLOCK &&
-        <a
-          onClick={handleShapeshiftClick}
-          href={shapeShiftLink(ethUtil.toChecksumAddress(account.proxy))}
-        >
-          <img src={shapeshiftButton} alt="Pay with Shapeshift" />
-        </a>
-      }
-
-      <Alert theme="warning">
-      Please note you´ll need some amount of ETH in your MetaMask wallet to pay transaction fees (table joins, transfers etc). Depending on the gas price you will need to pay ≈0.004 ETH to join the table.
-      </Alert>
-    </ReceiveWrapper>
-  </ReceiveSection>
-);
-AccountNotLocked.propTypes = {
-  account: PropTypes.object,
-  qrUrl: PropTypes.string,
-};
+export default SectionReceive;

--- a/app/components/Dashboard/SectionReceive.js
+++ b/app/components/Dashboard/SectionReceive.js
@@ -12,7 +12,7 @@ import shapeshiftButton from './shapeshift.png';
 import Alert from '../Alert';
 
 import DepositInfo from './DepositInfo';
-import { ReceiveWrapper, ReceiveSection } from './styles';
+import { ReceiveSection } from './styles';
 
 function handleShapeshiftClick(e) {
   e.preventDefault();
@@ -31,37 +31,35 @@ export const SectionReceive = (props) => {
   const { account, ethBalance, nutzBalance, floor } = props;
   return (
     <ReceiveSection>
-      <ReceiveWrapper>
-        <DepositInfo />
+      <DepositInfo />
 
-        {conf().firstBlockHash === MAIN_NET_GENESIS_BLOCK && (
-          <a
-            onClick={handleShapeshiftClick}
-            href={shapeShiftLink(ethUtil.toChecksumAddress(account.proxy))}
-          >
-            <img src={shapeshiftButton} alt="Pay with Shapeshift" />
-          </a>
+      {conf().firstBlockHash === MAIN_NET_GENESIS_BLOCK && (
+        <a
+          onClick={handleShapeshiftClick}
+          href={shapeShiftLink(ethUtil.toChecksumAddress(account.proxy))}
+        >
+          <img src={shapeshiftButton} alt="Pay with Shapeshift" />
+        </a>
+      )}
+
+      {account.isLocked &&
+        ethBalance &&
+        nutzBalance &&
+        floor && (
+          <Alert theme="warning" data-tour="wallet-unlock">
+            <FormattedMessage
+              values={{ limit: ETH_FISH_LIMIT.toString() }}
+              {...messages.ethLimit}
+            />
+            <BtnUpgrade {...{ account, messages }} />
+            <AccountProgress
+              ethBalance={ethBalance}
+              nutzBalance={nutzBalance}
+              floor={floor}
+              ethLimit={ETH_FISH_LIMIT}
+            />
+          </Alert>
         )}
-
-        {account.isLocked &&
-          ethBalance &&
-          nutzBalance &&
-          floor && (
-            <Alert theme="warning" data-tour="wallet-unlock">
-              <FormattedMessage
-                values={{ limit: ETH_FISH_LIMIT.toString() }}
-                {...messages.ethLimit}
-              />
-              <BtnUpgrade {...{ account, messages }} />
-              <AccountProgress
-                ethBalance={ethBalance}
-                nutzBalance={nutzBalance}
-                floor={floor}
-                ethLimit={ETH_FISH_LIMIT}
-              />
-            </Alert>
-          )}
-      </ReceiveWrapper>
     </ReceiveSection>
   );
 };

--- a/app/components/Dashboard/SectionReceive.js
+++ b/app/components/Dashboard/SectionReceive.js
@@ -12,60 +12,55 @@ import shapeshiftButton from './shapeshift.png';
 import Alert from '../Alert';
 
 import DepositInfo from './DepositInfo';
-import {
-  ReceiveWrapper,
-  ReceiveSection,
-} from './styles';
+import { ReceiveWrapper, ReceiveSection } from './styles';
 
 function handleShapeshiftClick(e) {
   e.preventDefault();
-  window.open(e.currentTarget.href, conf().shapeshiftKey, 'width=700,height=500,toolbar=0,menubar=0,location=0,status=1,scrollbars=1,resizable=0,left=0,top=0');
+  window.open(
+    e.currentTarget.href,
+    conf().shapeshiftKey,
+    'width=700,height=500,toolbar=0,menubar=0,location=0,status=1,scrollbars=1,resizable=0,left=0,top=0'
+  );
 }
 
-const shapeShiftLink = (proxy) => `https://shapeshift.io/shifty.html?destination=${proxy}&output=ETH&apiKey=${conf().shapeshiftKey}`;
+const shapeShiftLink = (proxy) =>
+  `https://shapeshift.io/shifty.html?destination=${proxy}&output=ETH&apiKey=${conf()
+    .shapeshiftKey}`;
 
 export const SectionReceive = (props) => {
-  const {
-    account,
-    ethBalance,
-    nutzBalance,
-    floor,
-  } = props;
+  const { account, ethBalance, nutzBalance, floor } = props;
   return (
     <ReceiveSection>
       <ReceiveWrapper>
-        <DepositInfo data-tour="wallet-address" />
+        <DepositInfo />
 
-        {conf().firstBlockHash === MAIN_NET_GENESIS_BLOCK &&
+        {conf().firstBlockHash === MAIN_NET_GENESIS_BLOCK && (
           <a
             onClick={handleShapeshiftClick}
             href={shapeShiftLink(ethUtil.toChecksumAddress(account.proxy))}
           >
             <img src={shapeshiftButton} alt="Pay with Shapeshift" />
           </a>
-        }
+        )}
 
-        {conf().firstBlockHash !== MAIN_NET_GENESIS_BLOCK &&
-          <Alert theme="danger">
-            <FormattedMessage {...messages.ethAlert} />
-          </Alert>
-        }
-        <Alert theme="warning">
-          Please note you´ll need some amount of ETH in your MetaMask wallet if you want to unlock account and pay transaction fees after unlock (table joins, transfers etc). Depending on the gas price you will need to pay ≈0.004 ETH to join the table.
-        </Alert>
-
-        {account.isLocked && ethBalance && nutzBalance && floor &&
-          <Alert theme="warning" data-tour="wallet-unlock">
-            <FormattedMessage values={{ limit: ETH_FISH_LIMIT.toString() }} {...messages.ethLimit} />
-            <BtnUpgrade {...{ account, messages }} />
-            <AccountProgress
-              ethBalance={ethBalance}
-              nutzBalance={nutzBalance}
-              floor={floor}
-              ethLimit={ETH_FISH_LIMIT}
-            />
-          </Alert>
-        }
+        {account.isLocked &&
+          ethBalance &&
+          nutzBalance &&
+          floor && (
+            <Alert theme="warning" data-tour="wallet-unlock">
+              <FormattedMessage
+                values={{ limit: ETH_FISH_LIMIT.toString() }}
+                {...messages.ethLimit}
+              />
+              <BtnUpgrade {...{ account, messages }} />
+              <AccountProgress
+                ethBalance={ethBalance}
+                nutzBalance={nutzBalance}
+                floor={floor}
+                ethLimit={ETH_FISH_LIMIT}
+              />
+            </Alert>
+          )}
       </ReceiveWrapper>
     </ReceiveSection>
   );

--- a/app/components/Dashboard/Wallet.js
+++ b/app/components/Dashboard/Wallet.js
@@ -12,7 +12,7 @@ import {
   SendContainer,
   TabIcon as ModeIcon,
 } from './styles';
-import { AccountIsLocked, AccountNotLocked } from './SectionReceive';
+import SectionReceive from './SectionReceive';
 
 function Wallet(props) {
   const {
@@ -24,9 +24,8 @@ function Wallet(props) {
     estimateNTZTransfer,
     estimateETHTransfer,
     amountUnit,
+    floor,
   } = props;
-
-  const AccComponent = account.isLocked ? AccountIsLocked : AccountNotLocked;
 
   return (
     <Pane name="dashboard-wallet">
@@ -35,7 +34,7 @@ function Wallet(props) {
         name="wallet-receive"
       >
         <H2><ModeIcon className="fa fa-inbox" />Deposit</H2>
-        <AccComponent {...props} />
+        <SectionReceive {...{ account, ethBalance, nutzBalance, floor }} />
       </Section>
 
       <Section name="wallet-send">
@@ -71,7 +70,6 @@ function Wallet(props) {
 }
 
 Wallet.propTypes = {
-  account: PropTypes.object,
   ethBalance: PropTypes.object,
   nutzBalance: PropTypes.object,
   handleNTZTransfer: PropTypes.func,
@@ -80,6 +78,8 @@ Wallet.propTypes = {
   estimateETHTransfer: PropTypes.func,
   amountUnit: PropTypes.string,
   messages: PropTypes.object,
+  account: PropTypes.object.isRequired,
+  floor: PropTypes.object.isRequired,
 };
 
 export default Wallet;

--- a/app/components/Dashboard/investTourMessages.js
+++ b/app/components/Dashboard/investTourMessages.js
@@ -71,8 +71,8 @@ export default defineMessages({
     id: 'app.containers.InvestTour.step5',
     defaultMessage: `
       <div>
-        <p>Deposit ether to your account address (in green).</p>
-        <Alert theme="info">You can deposit from any wallet, but make sure to leave at least 0.05ETH in MetaMask for future transactions.</Alert>
+        <p>Deposit ether to your account address.</p>
+        <Alert theme="info">You can deposit from any wallet, but make sure to leave at least 0.03ETH in MetaMask for future transactions.</Alert>
       </div>
     `,
   },

--- a/app/components/Dashboard/styles.js
+++ b/app/components/Dashboard/styles.js
@@ -42,18 +42,6 @@ export const SendContainer = styled.div`
   justify-content: center;
 `;
 
-export const Address = styled.p`
-  /* These are technically the same, but use both */
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-
-  /* Instead use this non-standard one: */
-  word-break: break-word;
-
-  /* Adds a hyphen where the word breaks, if supported (No Blink) */
-  margin: 0 0;
-`;
-
 export const ConfirmButton = styled(Button)`
   display: flex;
   justify-content: center;
@@ -86,9 +74,8 @@ export const ExchangeContainer = styled.div`
 // Overview
 export const ReceiveSection = styled.div`
   display: flex;
+  flex-direction: column;
 `;
-
-export const ReceiveWrapper = styled.div``;
 
 // Balances
 export const BalanceSection = styled.div`

--- a/app/components/Modal/ConfirmDialog.js
+++ b/app/components/Modal/ConfirmDialog.js
@@ -1,17 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import H2 from 'components/H2';
 import SubmitButton from 'components/SubmitButton';
+import {
+  DialogContents,
+  DialogTitle,
+  DialogButtonWrapper,
+} from 'components/Modal/styles';
 
 const ConfirmDialog = ({ title, msg, buttonText, onSubmit }) => (
-  <div>
-    {title && <H2>{title}</H2>}
+  <DialogContents>
+    {title && <DialogTitle>{title}</DialogTitle>}
     <p>{msg}</p>
-    <SubmitButton onClick={onSubmit}>
-      {buttonText}
-    </SubmitButton>
-  </div>
+    <DialogButtonWrapper>
+      <SubmitButton onClick={onSubmit}>
+        {buttonText}
+      </SubmitButton>
+    </DialogButtonWrapper>
+  </DialogContents>
 );
 ConfirmDialog.propTypes = {
   title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/app/components/Modal/DepositDialog.js
+++ b/app/components/Modal/DepositDialog.js
@@ -3,52 +3,76 @@ import PropTypes from 'prop-types';
 import QRCode from 'qrcode.react';
 import ethUtil from 'ethereumjs-util';
 import { FormattedMessage } from 'react-intl';
-import H2 from 'components/H2';
-import { Address } from 'components/Dashboard/styles';
 import messages from 'containers/Dashboard/messages';
 import SubmitButton from 'components/SubmitButton';
+import {
+  DialogContents,
+  DialogTitle,
+  DialogButtonWrapper,
+} from 'components/Modal/styles';
 import Alert from '../Alert';
 import WithLoading from '../WithLoading';
 import { MAIN_NET_GENESIS_BLOCK, conf } from '../../app.config';
 
-const DepositDialog = ({ account }) => {
+const styles = {
+  withLoadingOuter: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    alignItems: 'center',
+  },
+  address: {
+    fontSize: '18',
+    width: '100%',
+    textAlign: 'center',
+    padding: '12px 0',
+    margin: '5px 0',
+  },
+  alertMargins: {
+    margin: '5px 0',
+  },
+};
+
+const DepositDialog = ({ account, handleClose }) => {
   const qrUrl = `ether:${account.proxy}`;
   return (
-    <div>
-      <H2>Deposit Info</H2>
+    <DialogContents>
+      <DialogTitle>Ethereum and Nutz Deposit Info</DialogTitle>
       <WithLoading
         isLoading={!account.proxy || account.proxy === '0x'}
         loadingSize="40px"
-        styles={{
-          outer: { margin: 'auto' },
-        }}
+        styles={{ outer: styles.withLoadingOuter }}
       >
-        <QRCode value={qrUrl} size={100} />
-        <Alert style={{ margin: 'auto' }} theme="success">
-          <Address style={{ width: 180 }}>
-            {ethUtil.toChecksumAddress(account.proxy)}
-          </Address>
+        <div style={{ marginBottom: '10px' }}>
+          <QRCode value={qrUrl} size={160} />
+        </div>
+        <Alert style={styles.address} theme="success">
+          {ethUtil.toChecksumAddress(account.proxy)}
         </Alert>
       </WithLoading>
 
       {conf().firstBlockHash !== MAIN_NET_GENESIS_BLOCK && (
-        <Alert theme="danger">
+        <Alert style={styles.alertMargins} theme="danger">
           <FormattedMessage {...messages.ethAlert} />
         </Alert>
       )}
 
-      <Alert theme="warning">
+      <Alert style={styles.alertMargins} theme="warning">
         Please note you´ll need some amount of ETH in your MetaMask wallet if
         you want to unlock account and pay transaction fees after unlock (table
         joins, transfers etc). Depending on the gas price you will need to pay
         ≈0.004 ETH to join the table.
       </Alert>
-      <SubmitButton>OK</SubmitButton>
-    </div>
+
+      <DialogButtonWrapper>
+        <SubmitButton onClick={handleClose}>OK</SubmitButton>
+      </DialogButtonWrapper>
+    </DialogContents>
   );
 };
 DepositDialog.propTypes = {
   account: PropTypes.object.isRequired,
+  handleClose: PropTypes.func.isRequired,
 };
 
 export default DepositDialog;

--- a/app/components/Modal/DepositDialog.js
+++ b/app/components/Modal/DepositDialog.js
@@ -32,7 +32,7 @@ const styles = {
     margin: '5px 0',
   },
   qrCodeWrapper: {
-    margin: '10px 0 16px 0',
+    margin: '0 0 16px 0',
   },
 };
 
@@ -40,19 +40,19 @@ const DepositDialog = ({ account, handleClose }) => {
   const qrUrl = `ether:${account.proxy}`;
   return (
     <DialogContents>
-      <DialogTitle>Ethereum and Nutz Deposit Info</DialogTitle>
-      <WithLoading
-        isLoading={!account.proxy || account.proxy === '0x'}
-        loadingSize="40px"
-        styles={{ outer: styles.withLoadingOuter }}
-      >
-        <Alert style={styles.address} theme="none">
+      <Alert style={styles.address} theme="none">
+        <DialogTitle>Ethereum and Nutz Deposit</DialogTitle>
+        <WithLoading
+          isLoading={!account.proxy || account.proxy === '0x'}
+          loadingSize="40px"
+          styles={{ outer: styles.withLoadingOuter }}
+        >
           <div style={styles.qrCodeWrapper}>
             <QRCode value={qrUrl} size={160} />
           </div>
           {ethUtil.toChecksumAddress(account.proxy)}
-        </Alert>
-      </WithLoading>
+        </WithLoading>
+      </Alert>
 
       {conf().firstBlockHash !== MAIN_NET_GENESIS_BLOCK && (
         <Alert style={styles.alertMargins} theme="danger">

--- a/app/components/Modal/DepositDialog.js
+++ b/app/components/Modal/DepositDialog.js
@@ -22,14 +22,17 @@ const styles = {
     alignItems: 'center',
   },
   address: {
-    fontSize: '18',
+    fontSize: '1.2em',
     width: '100%',
     textAlign: 'center',
-    padding: '12px 0',
+    padding: '12px 0 16px 0',
     margin: '5px 0',
   },
   alertMargins: {
     margin: '5px 0',
+  },
+  qrCodeWrapper: {
+    margin: '10px 0 16px 0',
   },
 };
 
@@ -43,10 +46,10 @@ const DepositDialog = ({ account, handleClose }) => {
         loadingSize="40px"
         styles={{ outer: styles.withLoadingOuter }}
       >
-        <div style={{ marginBottom: '10px' }}>
-          <QRCode value={qrUrl} size={160} />
-        </div>
-        <Alert style={styles.address} theme="success">
+        <Alert style={styles.address} theme="none">
+          <div style={styles.qrCodeWrapper}>
+            <QRCode value={qrUrl} size={160} />
+          </div>
           {ethUtil.toChecksumAddress(account.proxy)}
         </Alert>
       </WithLoading>

--- a/app/components/Modal/DepositDialog.js
+++ b/app/components/Modal/DepositDialog.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import QRCode from 'qrcode.react';
+import ethUtil from 'ethereumjs-util';
+import { FormattedMessage } from 'react-intl';
+import H2 from 'components/H2';
+import { Address } from 'components/Dashboard/styles';
+import messages from 'containers/Dashboard/messages';
+import SubmitButton from 'components/SubmitButton';
+import Alert from '../Alert';
+import WithLoading from '../WithLoading';
+import { MAIN_NET_GENESIS_BLOCK, conf } from '../../app.config';
+
+const DepositDialog = ({ account }) => {
+  const qrUrl = `ether:${account.proxy}`;
+  return (
+    <div>
+      <H2>Deposit Info</H2>
+      <WithLoading
+        isLoading={!account.proxy || account.proxy === '0x'}
+        loadingSize="40px"
+        styles={{
+          outer: { margin: 'auto' },
+        }}
+      >
+        <QRCode value={qrUrl} size={100} />
+        <Alert style={{ margin: 'auto' }} theme="success">
+          <Address style={{ width: 180 }}>
+            {ethUtil.toChecksumAddress(account.proxy)}
+          </Address>
+        </Alert>
+      </WithLoading>
+
+      {conf().firstBlockHash !== MAIN_NET_GENESIS_BLOCK && (
+        <Alert theme="danger">
+          <FormattedMessage {...messages.ethAlert} />
+        </Alert>
+      )}
+
+      <Alert theme="warning">
+        Please note you´ll need some amount of ETH in your MetaMask wallet if
+        you want to unlock account and pay transaction fees after unlock (table
+        joins, transfers etc). Depending on the gas price you will need to pay
+        ≈0.004 ETH to join the table.
+      </Alert>
+      <SubmitButton>OK</SubmitButton>
+    </div>
+  );
+};
+DepositDialog.propTypes = {
+  account: PropTypes.object.isRequired,
+};
+
+export default DepositDialog;

--- a/app/components/Modal/FishWarningDialog.js
+++ b/app/components/Modal/FishWarningDialog.js
@@ -1,22 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { setFishWarned } from 'containers/Dashboard/actions';
+import { modalDismiss } from 'containers/App/actions';
 
 import SubmitButton from 'components/SubmitButton';
 import H2 from 'components/H2';
 
-const FishWarningDialog = ({ onSuccessButtonClick }) => (
-  <div>
-    <H2>Warning!</H2>
-    <span>Account limit 0.1 ETH. Higher deposits will be rejected.</span>
-    <br /><br />
-    <SubmitButton type="button" onClick={onSuccessButtonClick}>
-      Accept
-    </SubmitButton>
-  </div>
-);
-
+const FishWarningDialog = (props) => {
+  const handleAcceptClick = () => {
+    props.setFishWarned();
+    props.modalDismiss();
+    props.showDepositDialog();
+  };
+  return (
+    <div>
+      <H2>Warning!</H2>
+      <span>Account limit 0.1 ETH. Higher deposits will be rejected.</span>
+      <br />
+      <br />
+      <SubmitButton type="button" onClick={handleAcceptClick}>
+        Accept
+      </SubmitButton>
+    </div>
+  );
+};
 FishWarningDialog.propTypes = {
-  onSuccessButtonClick: PropTypes.func.isRequired,
+  setFishWarned: PropTypes.func.isRequired,
+  modalDismiss: PropTypes.func.isRequired,
+  showDepositDialog: PropTypes.func.isRequired,
 };
 
-export default FishWarningDialog;
+const mapStateToProps = () => ({});
+
+export default connect(mapStateToProps, {
+  setFishWarned,
+  modalDismiss,
+})(FishWarningDialog);

--- a/app/components/Modal/FishWarningDialog.js
+++ b/app/components/Modal/FishWarningDialog.js
@@ -5,7 +5,11 @@ import { setFishWarned } from 'containers/Dashboard/actions';
 import { modalDismiss } from 'containers/App/actions';
 
 import SubmitButton from 'components/SubmitButton';
-import H2 from 'components/H2';
+import {
+  DialogContents,
+  DialogTitle,
+  DialogButtonWrapper,
+} from 'components/Modal/styles';
 
 const FishWarningDialog = (props) => {
   const handleAcceptClick = () => {
@@ -14,15 +18,15 @@ const FishWarningDialog = (props) => {
     props.showDepositDialog();
   };
   return (
-    <div>
-      <H2>Warning!</H2>
-      <span>Account limit 0.1 ETH. Higher deposits will be rejected.</span>
-      <br />
-      <br />
-      <SubmitButton type="button" onClick={handleAcceptClick}>
-        Accept
-      </SubmitButton>
-    </div>
+    <DialogContents>
+      <DialogTitle>Warning!</DialogTitle>
+      Account limit 0.1 ETH. Higher deposits will be rejected.
+      <DialogButtonWrapper>
+        <SubmitButton type="button" onClick={handleAcceptClick}>
+          Accept
+        </SubmitButton>
+      </DialogButtonWrapper>
+    </DialogContents>
   );
 };
 FishWarningDialog.propTypes = {

--- a/app/components/Modal/index.js
+++ b/app/components/Modal/index.js
@@ -36,6 +36,7 @@ const Modal = ({ modal, handleClose }) => {
   if (modal) {
     SpecifiedModal = MODALS[modal.modalType];
   }
+  // console.log(modal.modalProps)
   return (
     <ModalsTransitionGroup>
       {modal && // required for leaveAnim
@@ -43,7 +44,7 @@ const Modal = ({ modal, handleClose }) => {
           <DialogTransitionGroup component={Modals}>
             <Background onClick={modal.modalProps.backdrop ? handleClose : null} />
             <DialogWrapper>
-              <SpecifiedModal {...modal.modalProps} />
+              <SpecifiedModal {...{ handleClose, ...modal.modalProps }} />
               <CloseButton onClick={handleClose}>
                 <XButton />
               </CloseButton>

--- a/app/components/Modal/index.js
+++ b/app/components/Modal/index.js
@@ -7,6 +7,7 @@ import * as modals from 'containers/Modal/constants';
 import ConfirmDialog from './ConfirmDialog';
 import SelectToken from './SelectToken';
 import FishWarningDialog from './FishWarningDialog';
+import DepositDialog from './DepositDialog';
 import ModalsTransitionGroup from './ModalsTransitionGroup';
 import { DialogTransitionGroup } from './DialogTransitionGroup';
 import { ContainerTransitionGroup } from './ContainerTransitionGroup';
@@ -22,6 +23,7 @@ import {
 
 const MODALS = {
   [modals.CONFIRM_DIALOG]: ConfirmDialog,
+  [modals.DEPOSIT_DIALOG]: DepositDialog,
   [modals.FISH_WARNING_DIALOG]: FishWarningDialog,
   [modals.INVITE_DIALOG]: InviteDialog,
   [modals.JOIN_DIALOG]: JoinDialog,

--- a/app/components/Modal/styles.js
+++ b/app/components/Modal/styles.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import H2 from 'components/H2';
 
 // Container
 export const Wrapper = styled.div`
@@ -54,6 +55,22 @@ export const DialogWrapper = styled.div`
   background: white;
   box-shadow: 0px 2px 15px rgba(0, 0, 0, 0.4);
   border-radius: 10px;
+`;
+
+export const DialogContents = styled.div`
+  width: 480px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const DialogTitle = styled(H2)`
+  margin-top: 0;
+`;
+
+export const DialogButtonWrapper = styled.div`
+  margin-top: 16px;
+  margin-bottom: 8px;
 `;
 
 export const CloseButton = styled.a`

--- a/app/containers/Dashboard/Wallet.js
+++ b/app/containers/Dashboard/Wallet.js
@@ -10,7 +10,7 @@ import { TRANSFER_NTZ, TRANSFER_ETH } from '../Notifications/constants';
 
 import makeSelectAccountData from '../AccountProvider/selectors';
 import messages from './messages';
-import { getAmountUnit, createIsFishWarnedSelector } from './selectors';
+import { getAmountUnit } from './selectors';
 
 import WalletComponent from '../../components/Dashboard/Wallet';
 
@@ -99,7 +99,6 @@ class Wallet extends React.Component {
           ethBalance: weiBalance && weiBalance.div(ETH_DECIMALS),
           nutzBalance: babzBalance && babzBalance.div(NTZ_DECIMALS),
           messages,
-          isFishWarned: this.props.isFishWarned,
           handleNTZTransfer: this.handleNTZTransfer,
           estimateNTZTransfer: this.estimateNTZTransfer,
           handleETHTransfer: this.handleETHTransfer,
@@ -115,13 +114,11 @@ Wallet.propTypes = {
   web3Redux: PropTypes.any,
   notifyCreate: PropTypes.func,
   amountUnit: PropTypes.string,
-  isFishWarned: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = createStructuredSelector({
   account: makeSelectAccountData(),
   amountUnit: getAmountUnit(),
-  isFishWarned: createIsFishWarnedSelector(),
 });
 
 export default web3Connect(

--- a/app/containers/Dashboard/Wallet.js
+++ b/app/containers/Dashboard/Wallet.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { createStructuredSelector } from 'reselect';
 import BigNumber from 'bignumber.js';
 
-import { modalAdd, modalDismiss } from '../App/actions';
 import web3Connect from '../AccountProvider/web3Connect';
 import { ETH_DECIMALS, NTZ_DECIMALS } from '../../utils/amountFormatter';
 import { notifyCreate } from '../Notifications/actions';
@@ -11,7 +10,7 @@ import { TRANSFER_NTZ, TRANSFER_ETH } from '../Notifications/constants';
 
 import makeSelectAccountData from '../AccountProvider/selectors';
 import messages from './messages';
-import { getAmountUnit } from './selectors';
+import { getAmountUnit, createIsFishWarnedSelector } from './selectors';
 
 import WalletComponent from '../../components/Dashboard/Wallet';
 
@@ -33,11 +32,6 @@ class Wallet extends React.Component {
     if (props.account.proxy) {
       this.proxy = this.web3.eth.contract(ABI_PROXY).at(props.account.proxy);
     }
-
-    this.fishWarn = this.fishWarn.bind(this);
-    this.state = {
-      isFishWarned: false,
-    };
   }
 
   componentWillReceiveProps(nextProps) {
@@ -49,14 +43,9 @@ class Wallet extends React.Component {
     }
   }
 
-  fishWarn() {
-    this.setState({ isFishWarned: true });
-  }
-
   handleTxSubmit(txFn) {
     return new Promise((resolve, reject) => {
       txFn((err, result) => {
-        this.props.modalDismiss();
         if (err) {
           reject(err);
         } else {
@@ -98,33 +87,24 @@ class Wallet extends React.Component {
   }
 
   render() {
-    const { account, amountUnit } = this.props;
-    const { isFishWarned } = this.state;
-    const qrUrl = `ether:${account.proxy}`;
+    const { account } = this.props;
     const weiBalance = this.web3.eth.balance(account.proxy);
-    const ethBalance = weiBalance && weiBalance.div(ETH_DECIMALS);
     const babzBalance = this.token.balanceOf(account.proxy);
-    const nutzBalance = babzBalance && babzBalance.div(NTZ_DECIMALS);
-    const floor = this.token.floor();
 
     return (
       <WalletComponent
         {...{
           account,
-          floor,
-          ethBalance,
-          nutzBalance,
-          qrUrl,
+          floor: this.token.floor(),
+          ethBalance: weiBalance && weiBalance.div(ETH_DECIMALS),
+          nutzBalance: babzBalance && babzBalance.div(NTZ_DECIMALS),
           messages,
-          isFishWarned,
+          isFishWarned: this.props.isFishWarned,
           handleNTZTransfer: this.handleNTZTransfer,
           estimateNTZTransfer: this.estimateNTZTransfer,
           handleETHTransfer: this.handleETHTransfer,
           estimateETHTransfer: this.estimateETHTransfer,
-          fishWarn: this.fishWarn,
-          amountUnit,
-          modalAdd: this.props.modalAdd,
-          modalDismiss: this.props.modalDismiss,
+          amountUnit: this.props.amountUnit,
         }}
       />
     );
@@ -135,20 +115,18 @@ Wallet.propTypes = {
   web3Redux: PropTypes.any,
   notifyCreate: PropTypes.func,
   amountUnit: PropTypes.string,
-  modalAdd: PropTypes.func.isRequired,
-  modalDismiss: PropTypes.func.isRequired,
+  isFishWarned: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = createStructuredSelector({
   account: makeSelectAccountData(),
   amountUnit: getAmountUnit(),
+  isFishWarned: createIsFishWarnedSelector(),
 });
 
 export default web3Connect(
   mapStateToProps,
   () => ({
     notifyCreate,
-    modalAdd,
-    modalDismiss,
   }),
 )(Wallet);

--- a/app/containers/Dashboard/actions.js
+++ b/app/containers/Dashboard/actions.js
@@ -14,6 +14,7 @@ export const SET_ACTIVE_TAB = 'acebusters/Dashboard/SET_ACTIVE_TAB';
 export const SET_AMOUNT_UNIT = 'acebusters/Dashboard/SET_AMOUNT_UNIT';
 export const SET_INVEST_TYPE = 'acebusters/Dashboard/SET_INVEST_TYPE';
 export const TOGGLE_INVEST_TOUR = 'acebusters/Dashboard/TOGGLE_INVEST_TOUR';
+export const SET_FISH_WARNED = 'acebusters/Dashboard/SET_FISH_WARNED';
 
 export const setActiveTab = (whichTab) => ({
   type: SET_ACTIVE_TAB,
@@ -32,4 +33,8 @@ export const setInvestType = (which) => ({
 
 export const toggleInvestTour = () => ({
   type: TOGGLE_INVEST_TOUR,
+});
+
+export const setFishWarned = () => ({
+  type: SET_FISH_WARNED,
 });

--- a/app/containers/Dashboard/reducer.js
+++ b/app/containers/Dashboard/reducer.js
@@ -15,6 +15,7 @@ import {
   SET_ACTIVE_TAB,
   SET_AMOUNT_UNIT,
   SET_INVEST_TYPE,
+  SET_FISH_WARNED,
   TOGGLE_INVEST_TOUR,
   OVERVIEW,
   ETH,
@@ -39,6 +40,7 @@ const confParams = conf();
  *   timestamp?: number;
  *   pending?: boolean;
  *   investTour: false;
+ *   isFishWarned: false;
  * }
  */
 const initialState = fromJS({
@@ -48,6 +50,7 @@ const initialState = fromJS({
   amountUnit: ETH,
   investType: POWERUP,
   investTour: false,
+  isFishWarned: false,
 });
 
 function dashboardReducer(state = initialState, action) {
@@ -117,6 +120,9 @@ function dashboardReducer(state = initialState, action) {
           }
           return state;
         });
+
+    case SET_FISH_WARNED:
+      return state.set('isFishWarned', true);
 
     default:
       return state;

--- a/app/containers/Dashboard/selectors.js
+++ b/app/containers/Dashboard/selectors.js
@@ -7,6 +7,11 @@ function selectDashboard(state) {
   return state.get('dashboard');
 }
 
+export const createIsFishWarnedSelector = () => createSelector(
+  selectDashboard,
+  (dashboard) => dashboard.get('isFishWarned'),
+);
+
 export const createDashboardTxsSelector = () => createSelector(
   selectDashboard,
   (dashboard) => ({

--- a/app/containers/Dashboard/tests/reducer.test.js
+++ b/app/containers/Dashboard/tests/reducer.test.js
@@ -11,6 +11,7 @@ describe('dashboard reducer tests', () => {
       events: null,
       investType: POWERUP,
       investTour: false,
+      isFishWarned: false,
       proxy: null,
     });
   });

--- a/app/containers/Modal/constants.js
+++ b/app/containers/Modal/constants.js
@@ -1,4 +1,5 @@
 export const CONFIRM_DIALOG = 'confirm_dialog';
+export const DEPOSIT_DIALOG = 'deposit_dialog';
 export const FISH_WARNING_DIALOG = 'fish_warning_dialog';
 export const INVITE_DIALOG = 'invite_dialog';
 export const JOIN_DIALOG = 'join_dialog';


### PR DESCRIPTION
* fix deposit styles for both fish and shark accounts
* move address, qr-code, warnings to modal
* fish clicks deposit info once, sees and dismisses fish-warning once per session, and then gets redirected to deposit info
* shark clicks deposit info and sees deposit info directly
* isFishWarned, and fishWarned func moved to redux states for Dashboard
* fixed tests
