### PR TITLE
Sandbox continuous deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 coverage
 build
 node_modules
+ab-web-frontend.zip
 stats.json
 
 # Cruft

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js -p --progress",
     "build:clean": "npm run test:clean && rimraf ./build",
     "build:dll": "node ./internals/scripts/dependencies.js",
+    "build:zip": "cd build && zip -r ../ab-web-frontend.zip * && cd ..",
     "start": "cross-env NODE_ENV=development node server",
     "start:tunnel": "cross-env NODE_ENV=development ENABLE_TUNNEL=true node server",
     "start:production": "npm run test && npm run build && npm run start:prod",
@@ -47,7 +48,8 @@
     "build-storybook": "build-storybook",
     "deploy:sandbox": "npm run deploy:sandbox:upload && npm run deploy:sandbox:invalidate-cache",
     "deploy:sandbox:upload": "aws s3 sync build/ s3://sandbox.acebusters.com/ --delete --acl public-read",
-    "deploy:sandbox:invalidate-cache": "aws cloudfront create-invalidation --distribution-id E3RARTII3ZDPBB --paths '/*'"
+    "deploy:sandbox:invalidate-cache": "aws cloudfront create-invalidation --distribution-id E3RARTII3ZDPBB --paths '/*'",
+    "deploy:sandbox:publish-artifact": "npm run build:zip && aws s3 cp ab-web-frontend.zip s3://builds.acebusters/sandbox/ab-web-frontend.zip"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "test:watch": "cross-env NODE_ENV=test jest --watchAll",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "deploy:sandbox": "npm run deploy:sandbox:upload && npm run deploy:sandbox:invalidate-cache",
+    "deploy:sandbox:upload": "aws s3 sync build/ s3://sandbox.acebusters.com/ --delete --acl public-read",
+    "deploy:sandbox:invalidate-cache": "aws cloudfront create-invalidation --distribution-id E3RARTII3ZDPBB --paths '/*'"
   },
   "lint-staged": {
     "*.js": [

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,6 +3,14 @@ language: node_js
 node_js:
   - 7.4.0
 
+env:
+  global:
+    # AWS_SANDBOX_KEY_ID, AWS_SANDBOX_KEY, AWS_STAGING_KEY_ID, AWS_STAGING_KEY
+    - secure: P6Nel0E9JIMff+mOno0U3bkH/JlRcevYG7wtI+u66wriAiVWRZCHEtoY3DW89Y2mVE20ojg3tZ8UUAhKOByuIKZo5jUzrVbsvgadClED06MFYg46jOpMuihsjYCHzgeasF81tzkoRBmkcNAtpsaQ4H1q/ZQQ8RbQ7pLcgGHUnFrmfpj/QEyefdFeS/GL9P3JNZ9QMwNtt8wJOYjM2vBm13RZ0QrCpxiSTHHrutag4+4hjUEYHydBC0nTltxAFbOunNNiWUosqwpBo7R7UmIx7mptR+8Obqc7sWqNn+bzFGDa6OVW9gHYNcPNLQXlGYt68v7wmpdYKTtTHwEJpIMy8Q==
+
+install:
+  - sudo apt-get install zip
+
 build:
 
   # http://docs.shippable.com/ci/shippableyml/#ci
@@ -13,17 +21,23 @@ build:
     - npm test
     - npm run build
 
+  post_ci:
+    - aws configure set preview.cloudfront true
+    - if [ "$BRANCH" == "develop" ] || [ "$BRANCH" == "master" ]; then DEPLOY=true; fi
+    # Deploy the app to sandbox.acebusters.com
+    - if [ "$DEPLOY" ]; then AWS_ACCESS_KEY_ID=$AWS_STAGING_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_STAGING_KEY npm run deploy:sandbox; fi
+    # Publish the app zip to S3 for later staging promotion
+    - if [ "$DEPLOY" ]; then AWS_ACCESS_KEY_ID=$AWS_STAGING_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_STAGING_KEY npm run deploy:sandbox:publish-artifact; fi
 
-# Integrations are used to connect external resources to CI
-# http://docs.shippable.com/integrations/overview/
-integrations:
-
-  # http://docs.shippable.com/ci/shippableyml/#notifications
   notifications:
-  # turning of email for PR builds, get notified only on failure and change in status
-  # http://docs.shippable.com/integrations/notifications/email/
-    - integrationName: email
-      type: email
+    - integrationName: slack_chainfish
+      type: slack
+      recipients:
+        - "#ci"
+      branches:
+        only:
+          - master
+          - develop
       on_success: change
       on_failure: always
-      on_pull_request: never
+      on_start: never

--- a/shippable.yml
+++ b/shippable.yml
@@ -23,7 +23,7 @@ build:
 
   post_ci:
     - aws configure set preview.cloudfront true
-    - if [ "$BRANCH" == "develop" ] || [ "$BRANCH" == "master" ]; then DEPLOY=true; fi
+    - if [ "$BRANCH" == "develop" -o "$BRANCH" == "master" ] && [ "$IS_PULL_REQUEST" == "false" ]; then DEPLOY=true; fi
     # Deploy the app to sandbox.acebusters.com
     - if [ "$DEPLOY" ]; then AWS_ACCESS_KEY_ID=$AWS_STAGING_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_STAGING_KEY npm run deploy:sandbox; fi
     # Publish the app zip to S3 for later staging promotion


### PR DESCRIPTION
**Shippable (automatic):**
On push to `develop` branch:
1. Build the app
2. Sync it to `s3://sandbox.acebusters.com/`
3. Invalidate CloudFront distribution for `sandbox.acebusters.com`
3. Upload zipped app to the `s3://builds.acebusters.com/sandbox/` (this copy will be used for Staging deployment)

**CLI (manual):**
Deploy to sandbox from local machine: `npm run deploy:sandbox`. This uploads `build/` folder to S3 and invalidates CF distribution.