### PR TITLE
Staging deployment pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "deploy:sandbox": "npm run deploy:sandbox:upload && npm run deploy:sandbox:invalidate-cache",
     "deploy:sandbox:upload": "aws s3 sync build/ s3://sandbox.acebusters.com/ --delete --acl public-read",
     "deploy:sandbox:invalidate-cache": "aws cloudfront create-invalidation --distribution-id E3RARTII3ZDPBB --paths '/*'",
-    "deploy:sandbox:publish-artifact": "npm run build:zip && aws s3 cp ab-web-frontend.zip s3://builds.acebusters/sandbox/ab-web-frontend.zip"
+    "deploy:sandbox:publish-artifact": "npm run build:zip && aws s3 cp ab-web-frontend.zip s3://builds.acebusters/sandbox/ab-web-frontend.zip",
+    "deploy:staging": "./scripts/deploy_staging.sh"
   },
   "lint-staged": {
     "*.js": [

--- a/scripts/deploy_staging.sh
+++ b/scripts/deploy_staging.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+declare -A lambdas
+
+lambdas["st-account-service"]="account-service"
+lambdas["st-contract-scanner"]="contract-scanner"
+lambdas["st-event-worker"]="event-worker"
+lambdas["st-interval-scanner"]="interval-scanner"
+lambdas["st-oracle-cashgame"]="oracle"
+lambdas["st-seat-reservation"]="reserve-service"
+lambdas["st-stream-scanner"]="stream-scanner"
+
+for function_name in ${!lambdas[@]}; do
+    zip_name=${lambdas[${function_name}]}
+
+    # Update Staging lambda with sandbox snapshot
+    aws lambda update-function-code --function-name ${function_name} --s3-bucket builds.acebusters --s3-key sandbox/${zip_name}.zip
+
+    # Copy sandbox snapshot as a Staging snapshot
+    aws s3 cp s3://builds.acebusters/sandbox/${zip_name}.zip s3://builds.acebusters/staging/${zip_name}.zip
+done
+
+# Download sandbox frontend snapshot
+aws s3 cp s3://builds.acebusters/sandbox/ab-web-frontend.zip ab-web-frontend.zip
+unzip ab-web-frontend.zip -d build_staging
+
+# Sync it to s3://staging.acebusters.com/
+aws s3 sync build_staging/ s3://staging.acebusters.com/ --delete --acl public-read
+rm -r build_staging
+
+# Invalidate staging.acebusters.com CloudFront distribution
+aws cloudfront create-invalidation --distribution-id E2IMWXGWRO29FC --paths '/*'

--- a/shippable.yml
+++ b/shippable.yml
@@ -17,17 +17,19 @@ build:
   ci:
     # npm mirrors can sometimes be flacky, better to use shippable_retry
     # http://docs.shippable.com/ci/advancedOptions/retry/
-    - shippable_retry npm install
+    - npm install
     - npm test
     - npm run build
 
   post_ci:
     - aws configure set preview.cloudfront true
-    - if [ "$BRANCH" == "develop" -o "$BRANCH" == "master" ] && [ "$IS_PULL_REQUEST" == "false" ]; then DEPLOY=true; fi
-    # Deploy the app to sandbox.acebusters.com
-    - if [ "$DEPLOY" ]; then AWS_ACCESS_KEY_ID=$AWS_STAGING_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_STAGING_KEY npm run deploy:sandbox; fi
-    # Publish the app zip to S3 for later staging promotion
-    - if [ "$DEPLOY" ]; then AWS_ACCESS_KEY_ID=$AWS_STAGING_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_STAGING_KEY npm run deploy:sandbox:publish-artifact; fi
+    - aws configure set region eu-west-1
+    - aws configure set aws_access_key_id $AWS_STAGING_KEY_ID
+    - aws configure set aws_secret_access_key $AWS_STAGING_KEY
+    # Deploy the app to sandbox.acebusters.com and publish the app zip to S3 for later staging promotion
+    - if [ "$BRANCH" == "develop" ] && [ "$IS_PULL_REQUEST" == "false" ]; then npm run deploy:sandbox && npm run deploy:sandbox:publish-artifact; fi
+    # Deploy the app to staging.acebusters.com and deploy backend from sandbox to staging lambdas
+    - if [[ "$BRANCH" == release/* ]]; then ./scripts/deploy_staging.sh; fi
 
   notifications:
     - integrationName: slack_chainfish

--- a/shippable.yml
+++ b/shippable.yml
@@ -40,6 +40,7 @@ build:
         only:
           - master
           - develop
+          - release/*
       on_success: change
       on_failure: always
       on_start: never


### PR DESCRIPTION
:robot: **Shippable (automatic):**
On push to `release/*` branch in `ab-web` repo:

1. Deploy all the zipped lambdas from `s3://builds.acebusters/sandbox` to STAGING (AWS cyfin)
2. Copy all the zipped lambdas to `s3://builds.acebusters/staging` (this copy may be used for promotion to PRODUCTION).
3. Unzip and deploy frontend from `s3://builds.acebusters/sandbox` to `s3://staging.acebusters.com/`
4. Invalidate CloudFront distribution for `staging.acebusters.com`

:man: **CLI (manual alternative):**
Deploy frontend+backend to staging from local machine using `npm run deploy:staging`