### PR TITLE
Action bar updates

### DIFF
--- a/app/components/ActionBar/FlagAmountBet.js
+++ b/app/components/ActionBar/FlagAmountBet.js
@@ -11,6 +11,15 @@ import {
 
 /* eslint-disable jsx-a11y/no-autofocus */
 class FlagAmountBet extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleRef = this.handleRef.bind(this);
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.sliderOpen !== this.props.sliderOpen && nextProps.sliderOpen && this.input) {
       setTimeout(() => {
@@ -19,42 +28,71 @@ class FlagAmountBet extends React.Component {
     }
   }
 
+  handleKeyDown(e) {
+    const { sb } = this.props;
+
+    switch (e.keyCode) { // eslint-disable-line default-case
+      case 38: // ↑
+        e.preventDefault();
+        this.handleIncrement(sb * 2);
+        break;
+
+      case 40: // ↓
+        e.preventDefault();
+        this.handleIncrement(-sb * 2);
+        break;
+    }
+  }
+
+  handleKeyUp(e) {
+    const { handleClickButton, setActionBarButtonActive, mode, active, disabled } = this.props;
+
+    if (e.keyCode === 13) { // Enter
+      if (!active || disabled || mode === BET) return;
+      setActionBarButtonActive(BET);
+      handleClickButton(BET);
+    }
+  }
+
+  handleChange(e) {
+    const { updateAmount, myStack, minRaise } = this.props;
+    updateAmount(
+      BigNumber.min(
+        BigNumber.max(
+          NTZ_DECIMALS.mul(Number(e.target.value)),
+          minRaise
+        ),
+        myStack
+      )
+    );
+  }
+
+  handleRef(input) {
+    this.input = input;
+  }
+
+  handleIncrement(value) {
+    const { amount, updateAmount, minRaise } = this.props;
+    updateAmount(BigNumber.max(amount + value, minRaise));
+  }
+
   render() {
-    const {
-      amount,
-      sliderOpen,
-      updateAmount,
-      handleClickButton,
-      setActionBarButtonActive,
-      mode,
-      active,
-      disabled,
-      myStack,
-      minRaise,
-    } = this.props;
+    const { amount, sliderOpen, sb } = this.props;
+
     return (
       <FlagBet sliderOpen={sliderOpen}>
-        <button onClick={() => updateAmount(BigNumber.max(amount - NTZ_DECIMALS.toNumber(), minRaise))}>
+        <button onClick={() => this.handleIncrement(-sb * 2)}>
           -
         </button>
         <input
-          ref={(input) => {
-            this.input = input;
-          }}
+          ref={this.handleRef}
           type="number"
           value={toNtz(amount)}
-          onChange={(e) => updateAmount(
-            BigNumber.min(BigNumber.max(NTZ_DECIMALS.mul(parseInt(e.target.value, 10)), minRaise), myStack)
-          )}
-          onKeyUp={(e) => {
-            if (e.keyCode === 13) {
-              if (!active || disabled || mode === BET) return;
-              setActionBarButtonActive(BET);
-              handleClickButton(BET);
-            }
-          }}
+          onChange={this.handleChange}
+          onKeyUp={this.handleKeyUp}
+          onKeyDown={this.handleKeyDown}
         />
-        <button onClick={() => updateAmount(BigNumber.min(amount + NTZ_DECIMALS.toNumber(), myStack))}>
+        <button onClick={() => this.handleIncrement(sb * 2)}>
           +
         </button>
       </FlagBet>
@@ -65,6 +103,7 @@ FlagAmountBet.propTypes = {
   amount: PropTypes.number,
   myStack: PropTypes.number,
   minRaise: PropTypes.number,
+  sb: PropTypes.number,
   updateAmount: PropTypes.func,
   sliderOpen: PropTypes.bool,
   handleClickButton: PropTypes.func,

--- a/app/components/ActionBar/FlagAmountBet.js
+++ b/app/components/ActionBar/FlagAmountBet.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import BigNumber from 'bignumber.js';
 
 import { FlagBet } from './styles';
-import { toNtz, NTZ_DECIMALS } from '../../utils/amountFormatter';
+import { formatNtz, NTZ_DECIMALS } from '../../utils/amountFormatter';
 
 import {
   BET,
@@ -29,17 +29,17 @@ class FlagAmountBet extends React.Component {
   }
 
   handleKeyDown(e) {
-    const { sb } = this.props;
+    const { sb, amount } = this.props;
 
     switch (e.keyCode) { // eslint-disable-line default-case
       case 38: // ↑
         e.preventDefault();
-        this.handleIncrement(sb * 2);
+        this.handleUpdate(amount + (sb * 2));
         break;
 
       case 40: // ↓
         e.preventDefault();
-        this.handleIncrement(-sb * 2);
+        this.handleUpdate(amount - (sb * 2));
         break;
     }
   }
@@ -55,13 +55,15 @@ class FlagAmountBet extends React.Component {
   }
 
   handleChange(e) {
-    const { updateAmount, myStack, minRaise } = this.props;
+    this.handleUpdate(NTZ_DECIMALS.mul(Number(e.target.value)));
+  }
+
+  handleUpdate(amount) {
+    const { updateAmount, minRaise, myStack } = this.props;
+
     updateAmount(
       BigNumber.min(
-        BigNumber.max(
-          NTZ_DECIMALS.mul(Number(e.target.value)),
-          minRaise
-        ),
+        BigNumber.max(amount, minRaise),
         myStack
       )
     );
@@ -71,28 +73,23 @@ class FlagAmountBet extends React.Component {
     this.input = input;
   }
 
-  handleIncrement(value) {
-    const { amount, updateAmount, minRaise } = this.props;
-    updateAmount(BigNumber.max(amount + value, minRaise));
-  }
-
   render() {
     const { amount, sliderOpen, sb } = this.props;
 
     return (
       <FlagBet sliderOpen={sliderOpen}>
-        <button onClick={() => this.handleIncrement(-sb * 2)}>
+        <button onClick={() => this.handleUpdate(amount - (sb * 2))}>
           -
         </button>
         <input
           ref={this.handleRef}
           type="number"
-          value={toNtz(amount)}
+          value={formatNtz(amount)}
           onChange={this.handleChange}
           onKeyUp={this.handleKeyUp}
           onKeyDown={this.handleKeyDown}
         />
-        <button onClick={() => this.handleIncrement(sb * 2)}>
+        <button onClick={() => this.handleUpdate(amount + (sb * 2))}>
           +
         </button>
       </FlagBet>

--- a/app/components/ActionBar/FlagButton.js
+++ b/app/components/ActionBar/FlagButton.js
@@ -4,35 +4,28 @@ import PropTypes from 'prop-types';
 import { FlagButtonWrapper } from './styles';
 
 const FlagButton = ({
-  potSize,
+  value,
+  label,
   minRaise,
   sliderOpen,
-  type,
   updateAmount,
 }) => {
-  const textType = () => {
-    if (type === 0.25) return '1/4';
-    if (type === 0.50) return '1/2';
-    if (type === 1.00) return 'POT';
-    return null;
-  };
-  const result = potSize * type;
-  const isDisabled = result <= minRaise;
+  const isDisabled = value <= minRaise;
   return (
     <FlagButtonWrapper
-      onClick={() => updateAmount(result)}
+      onClick={() => updateAmount(value)}
       sliderOpen={sliderOpen}
       name="flag-button"
       disabled={isDisabled}
     >
-      {textType()}
+      {label}
     </FlagButtonWrapper>
   );
 };
 FlagButton.propTypes = {
-  potSize: PropTypes.number,
+  value: PropTypes.number,
+  label: PropTypes.string,
   minRaise: PropTypes.number,
-  type: PropTypes.number,
   sliderOpen: PropTypes.bool,
   updateAmount: PropTypes.func,
 };

--- a/app/components/ActionBar/index.js
+++ b/app/components/ActionBar/index.js
@@ -25,38 +25,61 @@ const ActionBar = (props) => {
     disabled,
     sliderOpen,
     visible,
+    potSize,
+    state,
+    sb,
   } = props;
-  if (visible) {
-    return (
-      <ActionBarWrapper
-        active={active}
-        disabled={disabled}
-        name="action-bar-wrapper"
-      >
-
-        <FlagAmountCall {...props} />
-        <FlagAmountBet {...props} />
-        <FlagContainer active={active} name="flag-container">
-          <FlagButton type={0.25} {...props} />
-          <FlagButton type={0.50} {...props} />
-          <FlagButton type={1.00} {...props} />
-        </FlagContainer>
-
-        <ControlPanel name="control-panel-visible">
-          <ControlWrapper sliderOpen={sliderOpen} >
-            <ControlFold {...props} />
-            <ControlCheckCall {...props} />
-            <ControlBetRaise {...props} />
-            {sliderOpen &&
-              <Slider {...props} />
-            }
-          </ControlWrapper>
-        </ControlPanel>
-
-      </ActionBarWrapper>
-    );
+  if (!visible) {
+    return false;
   }
-  return null;
+
+  return (
+    <ActionBarWrapper
+      active={active}
+      disabled={disabled}
+      name="action-bar-wrapper"
+    >
+
+      <FlagAmountCall {...props} />
+      <FlagAmountBet {...props} />
+      <FlagContainer active={active} name="flag-container">
+        {state === 'preflop' &&
+          <FlagButton
+            value={sb * 6}
+            label="3BB"
+            {...props}
+          />
+        }
+        <FlagButton
+          value={potSize * 0.25}
+          label="1/4"
+          {...props}
+        />
+        <FlagButton
+          value={potSize * 0.5}
+          label="1/2"
+          {...props}
+        />
+        <FlagButton
+          value={potSize}
+          label="POT"
+          {...props}
+        />
+      </FlagContainer>
+
+      <ControlPanel name="control-panel-visible">
+        <ControlWrapper sliderOpen={sliderOpen} >
+          <ControlFold {...props} />
+          <ControlCheckCall {...props} />
+          <ControlBetRaise {...props} />
+          {sliderOpen &&
+            <Slider {...props} />
+          }
+        </ControlWrapper>
+      </ControlPanel>
+
+    </ActionBarWrapper>
+  );
 };
 
 ActionBar.propTypes = {
@@ -64,6 +87,9 @@ ActionBar.propTypes = {
   active: PropTypes.bool,
   disabled: PropTypes.bool,
   sliderOpen: PropTypes.bool,
+  potSize: PropTypes.number,
+  state: PropTypes.string,
+  sb: PropTypes.number,
 };
 
 export default ActionBar;

--- a/app/components/ActionBar/styles.js
+++ b/app/components/ActionBar/styles.js
@@ -143,7 +143,7 @@ export const ActionText = styled.div`
 
 export const SliderWrapper = styled.div`
   align-self: center;
-  width: 200px;
+  width: 230px;
   height: 20px;
   margin-left: 24px;
   margin-right: 24px;

--- a/app/containers/ActionBar/index.js
+++ b/app/containers/ActionBar/index.js
@@ -10,15 +10,8 @@ import { getTimeLeft } from '../Seat/index';
 import { playIsPlayerTurn } from '../../sounds';
 
 import {
-  handleClickButton,
-  setActionBarTurnComplete,
-  setActionBarButtonActive,
-  updateActionBar,
-  ALL_IN,
-  BET,
-  CHECK,
-  CALL,
-  FOLD,
+  handleClickButton, setActionBarTurnComplete, setActionBarButtonActive, updateActionBar,
+  ALL_IN, BET, CHECK, CALL, FOLD,
 } from './actions';
 
 import {
@@ -43,6 +36,8 @@ import {
   makeMessagesSelector,
   makePlayersCountSelector,
   makeLatestHandSelector,
+  makeHandStateSelector,
+  makeSbSelector,
 } from '../Table/selectors';
 
 import {
@@ -327,6 +322,8 @@ const mapStateToProps = createStructuredSelector({
   latestHand: makeLatestHandSelector(),
   canICheck: makeCanICheckSelector(),
   isMuted: makeSelectIsMuted(),
+  state: makeHandStateSelector(),
+  sb: makeSbSelector(),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ActionBarContainer);

--- a/app/containers/Table/index.js
+++ b/app/containers/Table/index.js
@@ -443,22 +443,20 @@ export class Table extends React.PureComponent { // eslint-disable-line react/pr
     // dispatch action according to event type
     switch (result.event) {
       case 'Join': {
-        const lineupReceivedArgs = (rsp) => [
-          this.tableAddr,
-          rsp,
-          this.props.data.get('smallBlind'),
-          this.props.latestHand,
-          this.props.myPendingSeat,
-        ];
-
+        // notify backend about change in lineup
         if (result.args && result.args.addr === this.props.proxyAddr) {
-          // notify backend about change in lineup
           this.tableService.lineup();
         }
 
         // update lineup when join successful
-        this.table.getLineup.callPromise().then((rsp) => {
-          this.props.lineupReceived(...lineupReceivedArgs(rsp));
+        this.table.getLineup.callPromise().then((lineup) => {
+          this.props.lineupReceived(
+            this.tableAddr,
+            lineup,
+            this.props.data.get('smallBlind'),
+            this.props.latestHand,
+            this.props.myPendingSeat,
+          );
         });
 
         break;


### PR DESCRIPTION
1. 3BB button (resolves #832)
2. Increase bet by BB in input (resolves #855)
3. Do not show decimals in bet input (resolves #813)

Currently, shortcuts (3BB, 1/2, 1/4, POT)  just set value for a bet. Maybe it should also submit bet?